### PR TITLE
Persist weights after training and load for prediction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod positional;
 mod predict;
 mod embedding_t;
 mod math;         // einfache Matrixops + softmax etc.
+mod weights;
 
 use std::env;
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -2,36 +2,7 @@ use crate::data::{to_matrix, Vocab, START, END};
 use crate::encoder_t::EncoderT;
 use crate::decoder_t::DecoderT;
 use crate::autograd::Tensor;
-use crate::math::Matrix;
-use serde::Deserialize;
-use std::fs;
-
-#[derive(Deserialize)]
-pub struct ModelJson {
-    pub encoder_embedding: Vec<Vec<f32>>,
-    pub decoder_embedding: Vec<Vec<f32>>,
-}
-
-pub fn load_model(path: &str, encoder: &mut EncoderT, decoder: &mut DecoderT) {
-    let txt = fs::read_to_string(path).unwrap_or_else(|_| "{}".to_string());
-    if let Ok(model) = serde_json::from_str::<ModelJson>(&txt) {
-        let e_rows = model.encoder_embedding.len();
-        let e_cols = model.encoder_embedding.get(0).map_or(0, |v| v.len());
-        let e_flat: Vec<f32> = model.encoder_embedding.into_iter().flatten().collect();
-        if e_rows > 0 && e_cols > 0 {
-            let mat = Matrix::from_vec(e_rows, e_cols, e_flat);
-            encoder.embedding.table.w = Tensor::from_matrix(mat, true);
-        }
-        let d_rows = model.decoder_embedding.len();
-        let d_cols = model.decoder_embedding.get(0).map_or(0, |v| v.len());
-        let d_flat: Vec<f32> = model.decoder_embedding.into_iter().flatten().collect();
-        if d_rows > 0 && d_cols > 0 {
-            let mat = Matrix::from_vec(d_rows, d_cols, d_flat);
-            decoder.embedding.table.w = Tensor::from_matrix(mat, true);
-        }
-    }
-    println!("Loaded weights from {}", path);
-}
+use crate::weights::load_model;
 
 pub fn run(input: &str) {
     let vocab = Vocab::build();

--- a/src/train_backprop.rs
+++ b/src/train_backprop.rs
@@ -2,7 +2,7 @@ use crate::data::{load_pairs, to_matrix, Vocab, START, END};
 use crate::encoder_t::EncoderT;
 use crate::decoder_t::DecoderT;
 use crate::autograd::Tensor;
-use serde_json::json;
+use crate::weights::save_model;
 
 // Tensor Backprop Training (simplified Adam hook)
 // now using Embedding => model_dim independent of vocab_size
@@ -83,10 +83,6 @@ pub fn run(_opt: &str) {
         }
     }
 
-    // Save JSON async
-    let model = json!({ "TODO": "export with embedding weights etc." });
-    std::thread::spawn(move || {
-        std::fs::write("model.json", serde_json::to_string(&model).unwrap()).unwrap();
-        println!("model.json saved asynchronously");
-    });
+    // Save trained weights
+    save_model("model.json", &encoder, Some(&decoder));
 }

--- a/src/train_elmo.rs
+++ b/src/train_elmo.rs
@@ -1,6 +1,6 @@
 use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::encoder_t::EncoderT;
-use crate::autograd::Tensor;
+use crate::weights::save_model;
 
 pub fn run() {
     let pairs = load_pairs();
@@ -43,4 +43,7 @@ pub fn run() {
             }
         }
     }
+
+    // Save trained encoder weights
+    save_model("model.json", &encoder, None);
 }

--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -1,6 +1,7 @@
 use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::encoder_t::EncoderT;
 use crate::autograd::Tensor;
+use crate::weights::save_model;
 
 pub fn run() {
     let pairs = load_pairs();
@@ -39,4 +40,7 @@ pub fn run() {
             }
         }
     }
+
+    // Save trained encoder weights
+    save_model("model.json", &encoder, None);
 }

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -1,0 +1,53 @@
+use crate::encoder_t::EncoderT;
+use crate::decoder_t::DecoderT;
+use crate::autograd::Tensor;
+use crate::math::Matrix;
+use serde::{Serialize, Deserialize};
+use std::fs;
+
+#[derive(Serialize, Deserialize)]
+pub struct ModelJson {
+    pub encoder_embedding: Vec<Vec<f32>>,
+    pub decoder_embedding: Vec<Vec<f32>>,
+}
+
+fn tensor_to_vec2(t: &Tensor) -> Vec<Vec<f32>> {
+    let m = &t.data;
+    (0..m.rows)
+        .map(|r| (0..m.cols).map(|c| m.get(r, c)).collect())
+        .collect()
+}
+
+pub fn save_model(path: &str, encoder: &EncoderT, decoder: Option<&DecoderT>) {
+    let enc_emb = tensor_to_vec2(&encoder.embedding.table.w);
+    let dec_emb = decoder
+        .map(|d| tensor_to_vec2(&d.embedding.table.w))
+        .unwrap_or_default();
+    let model = ModelJson { encoder_embedding: enc_emb, decoder_embedding: dec_emb };
+    if let Ok(txt) = serde_json::to_string(&model) {
+        let _ = fs::write(path, txt);
+        println!("Saved weights to {}", path);
+    }
+}
+
+pub fn load_model(path: &str, encoder: &mut EncoderT, decoder: &mut DecoderT) {
+    let txt = fs::read_to_string(path).unwrap_or_else(|_| "{}".to_string());
+    if let Ok(model) = serde_json::from_str::<ModelJson>(&txt) {
+        if !model.encoder_embedding.is_empty() {
+            let e_rows = model.encoder_embedding.len();
+            let e_cols = model.encoder_embedding[0].len();
+            let e_flat: Vec<f32> = model.encoder_embedding.into_iter().flatten().collect();
+            let mat = Matrix::from_vec(e_rows, e_cols, e_flat);
+            encoder.embedding.table.w = Tensor::from_matrix(mat, true);
+        }
+        if !model.decoder_embedding.is_empty() {
+            let d_rows = model.decoder_embedding.len();
+            let d_cols = model.decoder_embedding[0].len();
+            let d_flat: Vec<f32> = model.decoder_embedding.into_iter().flatten().collect();
+            let mat = Matrix::from_vec(d_rows, d_cols, d_flat);
+            decoder.embedding.table.w = Tensor::from_matrix(mat, true);
+        }
+    }
+    println!("Loaded weights from {}", path);
+}
+


### PR DESCRIPTION
## Summary
- add centralized weight save/load utilities
- persist weights after each training run
- load persisted weights in prediction mode

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68a16b9c1118832f9669e515c40a415d