### PR TITLE
Ensure translation is never empty

### DIFF
--- a/src/predict.rs
+++ b/src/predict.rs
@@ -30,6 +30,10 @@ pub fn run(input: &str) {
         }
         filtered.push(id);
     }
-    let translation = vocab.decode(&filtered);
+    let translation = if filtered.is_empty() {
+        "[no translation]".to_string()
+    } else {
+        vocab.decode(&filtered)
+    };
     println!("{{\"input\":\"{}\", \"translation\":\"{}\"}}", input, translation);
 }


### PR DESCRIPTION
## Summary
- add fallback output when decoder produces no tokens

## Testing
- `cargo test`
- `cargo run -- predict "hallo welt"`
- `cargo fmt -- --check` *(fails: Diff in /workspace/vanillanoprop/src/autograd.rs:29)*


------
https://chatgpt.com/codex/tasks/task_e_68a1fedafe44832f8fc68dd05efeb0eb