### PR TITLE
Add epoch progress bars

### DIFF
--- a/src/train_backprop.rs
+++ b/src/train_backprop.rs
@@ -23,8 +23,10 @@ pub fn run(_opt: &str) {
     let start_id = *vocab.stoi.get(START).unwrap();
     let end_id = *vocab.stoi.get(END).unwrap();
 
-    for epoch in 0..50 {
-        let pb = ProgressBar::new(pairs.len() as u64);
+    let epochs = 50;
+    let pb = ProgressBar::new(epochs as u64);
+    for epoch in 0..epochs {
+        let mut last_loss = 0.0;
         for (src, tgt) in &pairs {
             // Encode
             let enc_x = to_matrix(src, vocab_size);
@@ -35,8 +37,7 @@ pub fn run(_opt: &str) {
 
             // CrossEntropy-Loss
             let loss = cross_entropy(&decoder, &enc_out, &generated, tgt, vocab_size);
-            pb.set_message(format!("epoch {epoch} loss {loss:.4}"));
-            pb.inc(1);
+            last_loss = loss;
 
             // Adam-Update Placeholder
             for layer in &mut encoder.layers {
@@ -45,8 +46,10 @@ pub fn run(_opt: &str) {
                 }
             }
         }
-        pb.finish_with_message(format!("epoch {epoch} done"));
+        pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
+        pb.inc(1);
     }
+    pb.finish_with_message("training done");
 
     // Save trained weights
     save_model("model.json", &encoder, Some(&decoder));

--- a/src/train_elmo.rs
+++ b/src/train_elmo.rs
@@ -13,8 +13,10 @@ pub fn run() {
     let mut encoder = EncoderT::new(6, vocab_size, model_dim, 1, 128);
     let lr = 0.001;
 
-    for epoch in 0..5 {
-        let pb = ProgressBar::new(pairs.len() as u64);
+    let epochs = 5;
+    let pb = ProgressBar::new(epochs as u64);
+    for epoch in 0..epochs {
+        let mut last_loss = 0.0;
         for (src, tgt) in &pairs {
             let x = to_matrix(src, vocab_size);
             let out = encoder.forward(&x);
@@ -35,8 +37,7 @@ pub fn run() {
                 cnt += 1.0;
             }
             let loss = ce / cnt;
-            pb.set_message(format!("epoch {epoch} loss {loss:.4}"));
-            pb.inc(1);
+            last_loss = loss;
 
             // dummy weight update
             for layer in &mut encoder.layers {
@@ -45,8 +46,10 @@ pub fn run() {
                 }
             }
         }
-        pb.finish_with_message(format!("epoch {epoch} done"));
+        pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
+        pb.inc(1);
     }
+    pb.finish_with_message("training done");
 
     save_model("model.json", &encoder, None);
 }

--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -12,8 +12,10 @@ pub fn run() {
     let mut encoder = EncoderT::new(6, vocab_size, model_dim, 1, 256);
     let lr = 0.001;
 
-    for epoch in 0..5 {
-        let pb = ProgressBar::new(pairs.len() as u64);
+    let epochs = 5;
+    let pb = ProgressBar::new(epochs as u64);
+    for epoch in 0..epochs {
+        let mut last_loss = 0.0;
         for (src, tgt) in &pairs {
             let x = to_matrix(src, vocab_size);
             let enc_out = encoder.forward(&x);
@@ -41,11 +43,12 @@ pub fn run() {
                     layer.attn.wq.w.data.data[idx] -= lr * d;
                 }
             }
-            pb.set_message(format!("epoch {epoch} loss {loss:.4}"));
-            pb.inc(1);
+            last_loss = loss;
         }
-        pb.finish_with_message(format!("epoch {epoch} done"));
+        pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
+        pb.inc(1);
     }
+    pb.finish_with_message("training done");
 
     save_model("model.json", &encoder, None);
 }


### PR DESCRIPTION
## Summary
- show epoch-level progress bars during backprop training
- show epoch-level progress bars during noprop training
- show epoch-level progress bars during elmo training

## Testing
- `cargo run -- backprop`
- `cargo run -- elmo`
- `cargo run -- noprop`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8f295188832fb47b1864b515eeb6