### PR TITLE
Use MNIST dataset for training methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8"
 indicatif = "0.17"
+mnist = { version = "0.6", features = ["download"] }
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # vanillanoprop
-Vanilla implementation of no prop 
+Vanilla implementation of no prop
+
+Training examples now use the [MNIST](http://yann.lecun.com/exdb/mnist/) dataset for
+standard backpropagation, NoProp, and an ELMo-inspired method.

--- a/src/train_backprop.rs
+++ b/src/train_backprop.rs
@@ -1,4 +1,4 @@
-use crate::data::{load_pairs, to_matrix, Vocab, START, END};
+use crate::data::{load_mnist_pairs, to_matrix, Vocab, START, END};
 use crate::transformer_t::{DecoderT, EncoderT};
 use crate::autograd::Tensor;
 use crate::weights::save_model;
@@ -11,8 +11,8 @@ fn naive_decode(start_id: usize, end_id: usize) -> Vec<usize> {
 // Tensor Backprop Training (simplified Adam hook)
 // now using Embedding => model_dim independent of vocab_size
 pub fn run(_opt: &str) {
-    let pairs = load_pairs();
-    let vocab = Vocab::build();
+    let pairs = load_mnist_pairs();
+    let vocab = Vocab::build_mnist();
     let vocab_size = vocab.itos.len();
 
     let model_dim = 64;

--- a/src/train_elmo.rs
+++ b/src/train_elmo.rs
@@ -1,11 +1,11 @@
-use crate::data::{load_pairs, to_matrix, Vocab};
+use crate::data::{load_mnist_pairs, to_matrix, Vocab};
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
 
 pub fn run() {
-    let pairs = load_pairs();
-    let vocab = Vocab::build();
+    let pairs = load_mnist_pairs();
+    let vocab = Vocab::build_mnist();
     let vocab_size = vocab.itos.len();
 
     // With embedding → model_dim separate

--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -1,11 +1,11 @@
-use crate::data::{load_pairs, to_matrix, Vocab};
+use crate::data::{load_mnist_pairs, to_matrix, Vocab};
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
 
 pub fn run() {
-    let pairs = load_pairs();
-    let vocab = Vocab::build();
+    let pairs = load_mnist_pairs();
+    let vocab = Vocab::build_mnist();
     let vocab_size = vocab.itos.len();
 
     let model_dim = 64;


### PR DESCRIPTION
## Summary
- add mnist dependency
- load MNIST dataset and build dedicated vocabulary
- use MNIST pairs in backprop, NoProp, and ELMo training examples
- document MNIST usage in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aa938c5e98832fb5457bc00dfbab8c