### PR TITLE
Add MNIST download CLI option

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -88,6 +88,23 @@ pub fn load_mnist_pairs() -> Vec<(Vec<usize>, Vec<usize>)> {
         .collect()
 }
 
+/// Download the MNIST dataset into the local `data/` directory.
+///
+/// This uses the `mnist` crate's built-in downloader which fetches the
+/// required archive files and extracts them so that a file like
+/// `data/train-images-idx3-ubyte` is available.
+///
+/// The function does not return the dataset; it simply ensures that the
+/// files exist on disk for subsequent training runs.
+pub fn download_mnist() {
+    // `finalize` triggers the download when `download_and_extract` is
+    // enabled. We drop the returned data since we only care about the
+    // side effect of fetching the files.
+    let _ = MnistBuilder::new()
+        .download_and_extract()
+        .finalize();
+}
+
 pub fn to_matrix(seq: &[usize], vocab_size: usize) -> Matrix {
     let mut m = Matrix::zeros(seq.len(), vocab_size);
     for (i, &tok) in seq.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     args.push(String::from("backprop"));
     if args.len() < 2 {
         eprintln!("Usage: {} <mode> [optimizer|reload|input]", args[0]);
-        eprintln!("Modes: backprop | elmo | noprop | predict");
+        eprintln!("Modes: backprop | elmo | noprop | predict | download");
         return;
     }
 
@@ -39,6 +39,9 @@ fn main() {
         "predict" => {
             let input = args.get(2).expect("provide input sentence");
             predict::run(input);
+        }
+        "download" => {
+            data::download_mnist();
         }
         _ => eprintln!("Unknown mode {}", mode),
     }


### PR DESCRIPTION
## Summary
- add `download` mode that retrieves and extracts MNIST data
- expose helper in `data.rs` to fetch MNIST files into `data/`

## Testing
- `cargo check`
- `cargo run -- download` *(fails: invalid gzip header, likely due to partial download / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aa953838dc832f9a0288c8ec15c9cf