### PR TITLE
Replace sentence dataset with MNIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # vanillanoprop
-Vanilla implementation of no prop
+Vanilla implementation of no prop.
 
-Training examples now use the [MNIST](http://yann.lecun.com/exdb/mnist/) dataset for
-standard backpropagation, NoProp, and an ELMo-inspired method.
+This crate has been fully adapted to operate on the
+[MNIST](http://yann.lecun.com/exdb/mnist/) dataset. The sentence-based
+examples have been removed in favour of treating each image as a sequence of
+pixel values. The training modes (standard backpropagation, NoProp, and an
+ELMo-inspired method) now all use these image/label pairs.

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,13 +1,6 @@
 use crate::math::Matrix;
 use mnist::MnistBuilder;
 
-static DATA: &[(&str, &str)] = &[
-    ("hallo welt", "hello world"),
-    ("ich liebe rust", "i love rust"),
-    ("das ist gut", "that is good"),
-    ("wie geht es dir", "how are you"),
-];
-
 pub const START: &str = "<start>";
 pub const END: &str = "<end>";
 
@@ -17,28 +10,8 @@ pub struct Vocab {
 }
 
 impl Vocab {
+    /// Build a vocabulary for MNIST pixel values plus start/end tokens.
     pub fn build() -> Self {
-        let mut set = std::collections::HashSet::new();
-        set.insert(START.to_string());
-        set.insert(END.to_string());
-        for (s, t) in DATA.iter() {
-            for w in s.split_whitespace() {
-                set.insert(w.to_string());
-            }
-            for w in t.split_whitespace() {
-                set.insert(w.to_string());
-            }
-        }
-        let mut itos: Vec<String> = set.into_iter().collect();
-        itos.sort();
-        let mut stoi = std::collections::HashMap::new();
-        for (i, w) in itos.iter().enumerate() {
-            stoi.insert(w.clone(), i);
-        }
-        Self { stoi, itos }
-    }
-
-    pub fn build_mnist() -> Self {
         let mut itos: Vec<String> = (0..256).map(|i| i.to_string()).collect();
         itos.push(START.to_string());
         itos.push(END.to_string());
@@ -63,19 +36,13 @@ impl Vocab {
     }
 }
 
+/// Load a small portion of the MNIST dataset as (image, label) pairs.
 pub fn load_pairs() -> Vec<(Vec<usize>, Vec<usize>)> {
-    let vocab = Vocab::build();
-    DATA.iter()
-        .map(|(a, b)| (vocab.encode(a), vocab.encode(b)))
-        .collect()
-}
-
-pub fn load_mnist_pairs() -> Vec<(Vec<usize>, Vec<usize>)> {
     let mnist = MnistBuilder::new()
         .label_format_digit()
         .training_set_length(10)
         .finalize();
-    let end_id = *Vocab::build_mnist().stoi.get(END).unwrap();
+    let end_id = *Vocab::build().stoi.get(END).unwrap();
     mnist
         .trn_img
         .chunks(28 * 28)

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,4 +1,4 @@
-use crate::data::{load_mnist_pairs, to_matrix, Vocab, END, START};
+use crate::data::{load_pairs, to_matrix, Vocab, END, START};
 use crate::decoding::beam_search_decode;
 use crate::transformer_t::{DecoderT, EncoderT};
 use crate::weights::load_model;
@@ -6,12 +6,12 @@ use rand::Rng;
 
 pub fn run() {
     // pick a random image from the MNIST training pairs
-    let pairs = load_mnist_pairs();
+    let pairs = load_pairs();
     let mut rng = rand::thread_rng();
     let idx = rng.gen_range(0..pairs.len());
     let (src, tgt) = &pairs[idx];
 
-    let vocab = Vocab::build_mnist();
+    let vocab = Vocab::build();
     let vocab_size = vocab.itos.len();
     let start_id = *vocab.stoi.get(START).unwrap();
     let end_id = *vocab.stoi.get(END).unwrap();

--- a/src/train_backprop.rs
+++ b/src/train_backprop.rs
@@ -1,4 +1,4 @@
-use crate::data::{load_mnist_pairs, to_matrix, Vocab, START, END};
+use crate::data::{load_pairs, to_matrix, Vocab, START, END};
 use crate::transformer_t::{DecoderT, EncoderT};
 use crate::autograd::Tensor;
 use crate::weights::save_model;
@@ -11,8 +11,8 @@ fn naive_decode(start_id: usize, end_id: usize) -> Vec<usize> {
 // Tensor Backprop Training (simplified Adam hook)
 // now using Embedding => model_dim independent of vocab_size
 pub fn run(_opt: &str) {
-    let pairs = load_mnist_pairs();
-    let vocab = Vocab::build_mnist();
+    let pairs = load_pairs();
+    let vocab = Vocab::build();
     let vocab_size = vocab.itos.len();
 
     let model_dim = 64;

--- a/src/train_elmo.rs
+++ b/src/train_elmo.rs
@@ -1,11 +1,11 @@
-use crate::data::{load_mnist_pairs, to_matrix, Vocab};
+use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
 
 pub fn run() {
-    let pairs = load_mnist_pairs();
-    let vocab = Vocab::build_mnist();
+    let pairs = load_pairs();
+    let vocab = Vocab::build();
     let vocab_size = vocab.itos.len();
 
     // With embedding → model_dim separate

--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -1,11 +1,11 @@
-use crate::data::{load_mnist_pairs, to_matrix, Vocab};
+use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
 
 pub fn run() {
-    let pairs = load_mnist_pairs();
-    let vocab = Vocab::build_mnist();
+    let pairs = load_pairs();
+    let vocab = Vocab::build();
     let vocab_size = vocab.itos.len();
 
     let model_dim = 64;
@@ -20,7 +20,7 @@ pub fn run() {
             let x = to_matrix(src, vocab_size);
             let enc_out = encoder.forward(&x);
 
-            // encode target sentence with the same encoder to obtain a
+            // encode the target label sequence with the same encoder to obtain a
             // comparable representation and add a bit of noise
             let mut noisy = encoder.forward(&to_matrix(tgt, vocab_size));
             for v in &mut noisy.data.data {


### PR DESCRIPTION
## Summary
- drop placeholder sentence corpus and build vocab from MNIST pixel values
- load image/label pairs via `load_pairs` and update training/prediction to use it
- document the project as fully MNIST-based

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aaa22afc78832f8c8b291180a3d800