### PR TITLE
Add decoder projection layer and fix beam search token loop

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -54,7 +54,7 @@ pub fn beam_search_decode(
             let logits = decoder.forward(&Tensor::from_matrix(tin), enc_out);
             let probs = Tensor::softmax(&logits);
             let last = probs.data.rows - 1;
-            for tok in 0..vocab_size {
+            for tok in 0..probs.data.cols {
                 let p = probs.data.get(last, tok).max(1e-9).ln();
                 let mut new_seq = seq.clone();
                 new_seq.push(tok);

--- a/src/transformer_t.rs
+++ b/src/transformer_t.rs
@@ -185,6 +185,7 @@ impl DecoderLayerT {
 pub struct DecoderT {
     pub layers: Vec<DecoderLayerT>,
     pub embedding: EmbeddingT,
+    pub proj: LinearT,
 }
 
 impl DecoderT {
@@ -196,6 +197,7 @@ impl DecoderT {
         Self {
             layers: v,
             embedding: EmbeddingT::new(vocab_size, model_dim),
+            proj: LinearT::new(model_dim, vocab_size),
         }
     }
 
@@ -205,7 +207,7 @@ impl DecoderT {
         for l in &self.layers {
             h = l.forward(&h, enc_out);
         }
-        h
+        self.proj.forward(&h)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add final LinearT projection in `DecoderT` to map model dimension to vocabulary logits.
- Apply projection in decoder forward pass.
- Iterate over the output probability columns in `beam_search_decode` to avoid vocab mismatches.

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aab82ba400832fbdee3b96a9613d53