### PR TITLE
Add checkpointing based on F1 score

### DIFF
--- a/src/train_backprop.rs
+++ b/src/train_backprop.rs
@@ -28,6 +28,7 @@ pub fn run(_opt: &str) {
     math::reset_matrix_ops();
     let epochs = 50;
     let pb = ProgressBar::new(epochs as u64);
+    let mut best_f1 = f32::NEG_INFINITY;
     for epoch in 0..epochs {
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
@@ -59,6 +60,14 @@ pub fn run(_opt: &str) {
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
         pb.inc(1);
+
+        if avg_f1 > best_f1 {
+            println!(
+                "Checkpoint saved at epoch {epoch}: avg F1 improved to {avg_f1:.4}"
+            );
+            best_f1 = avg_f1;
+            save_model("checkpoint.json", &encoder, Some(&decoder));
+        }
     }
     pb.finish_with_message("training done");
 

--- a/src/train_elmo.rs
+++ b/src/train_elmo.rs
@@ -18,6 +18,7 @@ pub fn run() {
     math::reset_matrix_ops();
     let epochs = 5;
     let pb = ProgressBar::new(epochs as u64);
+    let mut best_f1 = f32::NEG_INFINITY;
     for epoch in 0..epochs {
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
@@ -68,6 +69,14 @@ pub fn run() {
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
         pb.inc(1);
+
+        if avg_f1 > best_f1 {
+            println!(
+                "Checkpoint saved at epoch {epoch}: avg F1 improved to {avg_f1:.4}"
+            );
+            best_f1 = avg_f1;
+            save_model("checkpoint.json", &encoder, None);
+        }
     }
     pb.finish_with_message("training done");
 

--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -17,6 +17,7 @@ pub fn run() {
     math::reset_matrix_ops();
     let epochs = 5;
     let pb = ProgressBar::new(epochs as u64);
+    let mut best_f1 = f32::NEG_INFINITY;
     for epoch in 0..epochs {
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
@@ -57,6 +58,14 @@ pub fn run() {
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
         pb.inc(1);
+
+        if avg_f1 > best_f1 {
+            println!(
+                "Checkpoint saved at epoch {epoch}: avg F1 improved to {avg_f1:.4}"
+            );
+            best_f1 = avg_f1;
+            save_model("checkpoint.json", &encoder, None);
+        }
     }
     pb.finish_with_message("training done");
 


### PR DESCRIPTION
## Summary
- Save model checkpoints whenever epoch average F1 improves
- Log checkpoint saves with reason for saving

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aac325b1f0832f914d6acebfdf0b52