### PR TITLE
Add convolutional preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@ Vanilla implementation of no prop.
 This crate has been fully adapted to operate on the
 [MNIST](http://yann.lecun.com/exdb/mnist/) dataset. The sentence-based
 examples have been removed in favour of treating each image as a sequence of
-pixel values. The training modes (standard backpropagation, NoProp, and an
-ELMo-inspired method) now all use these image/label pairs.
+pixel values. A light 3x3 mean convolution is applied to each image during
+loading to provide basic convolutional preprocessing. The training modes
+(standard backpropagation, NoProp, and an ELMo-inspired method) now all use
+these image/label pairs.


### PR DESCRIPTION
## Summary
- apply simple 3x3 mean convolution to MNIST images before training
- note convolution step in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aac85c9958832f92cd6eec1da05097