### PR TITLE
Add optimizer module with Adam and SGD and integrate into training scripts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod math; // einfache Matrixops + softmax etc.
 mod metrics;
 mod positional;
 mod predict;
+mod optim;
 mod train_backprop;
 mod train_elmo;
 mod train_noprop;

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -1,0 +1,21 @@
+use crate::transformer_t::LinearT;
+
+pub struct Adam {
+    pub lr: f32,
+    pub beta1: f32,
+    pub beta2: f32,
+    pub eps: f32,
+    pub weight_decay: f32,
+}
+
+impl Adam {
+    pub fn new(lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) -> Self {
+        Self { lr, beta1, beta2, eps, weight_decay }
+    }
+
+    pub fn step(&mut self, params: &mut [&mut LinearT]) {
+        for p in params.iter_mut() {
+            p.adam_step(self.lr, self.beta1, self.beta2, self.eps, self.weight_decay);
+        }
+    }
+}

--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -1,0 +1,5 @@
+pub mod adam;
+pub mod sgd;
+
+pub use adam::Adam;
+pub use sgd::SGD;

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,0 +1,18 @@
+use crate::transformer_t::LinearT;
+
+pub struct SGD {
+    pub lr: f32,
+    pub weight_decay: f32,
+}
+
+impl SGD {
+    pub fn new(lr: f32, weight_decay: f32) -> Self {
+        Self { lr, weight_decay }
+    }
+
+    pub fn step(&mut self, params: &mut [&mut LinearT]) {
+        for p in params.iter_mut() {
+            p.sgd_step(self.lr, self.weight_decay);
+        }
+    }
+}

--- a/src/train_elmo.rs
+++ b/src/train_elmo.rs
@@ -1,6 +1,7 @@
 use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::math;
 use crate::metrics::f1_score;
+use crate::optim::Adam;
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
@@ -17,6 +18,8 @@ pub fn run() {
     let beta1 = 0.9;
     let beta2 = 0.999;
     let eps = 1e-8;
+    let weight_decay = 0.0;
+    let mut optim = Adam::new(lr, beta1, beta2, eps, weight_decay);
 
     math::reset_matrix_ops();
     let epochs = 5;
@@ -35,7 +38,8 @@ pub fn run() {
 
             // backprop + optimisation
             encoder.backward(&grad);
-            encoder.adam_step(lr, beta1, beta2, eps);
+            let mut params = encoder.parameters();
+            optim.step(&mut params);
 
             let f1 = f1_score(&preds, tgt);
             f1_sum += f1;

--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -1,6 +1,7 @@
 use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::math::{self, Matrix};
 use crate::metrics::f1_score;
+use crate::optim::Adam;
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
@@ -16,6 +17,8 @@ pub fn run() {
     let beta1 = 0.9;
     let beta2 = 0.999;
     let eps = 1e-8;
+    let weight_decay = 0.0;
+    let mut optim = Adam::new(lr, beta1, beta2, eps, weight_decay);
 
     math::reset_matrix_ops();
     let epochs = 5;
@@ -54,7 +57,8 @@ pub fn run() {
             last_loss = loss;
 
             encoder.backward(&grad);
-            encoder.adam_step(lr, beta1, beta2, eps);
+            let mut params = encoder.parameters();
+            optim.step(&mut params);
 
             let f1 = f1_score(&src[..tgt.len().min(src.len())], tgt);
             f1_sum += f1;


### PR DESCRIPTION
## Summary
- Add `optim` module with Adam and SGD optimizers supporting learning rate, betas and weight decay
- Provide parameter traversal in model components for optimizer updates
- Update training scripts to build optimizer instances and step after backprop

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aacf0d6e18832f8cfea3e283dda2ff