### PR TITLE
Add batch training and gradient accumulation

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -70,6 +70,19 @@ pub fn load_pairs() -> Vec<(Vec<usize>, Vec<usize>)> {
         .collect()
 }
 
+/// Return the dataset grouped into mini-batches of the given size.
+///
+/// Batching allows training code to accumulate gradients across several
+/// samples before performing an optimisation step.  The final batch may be
+/// smaller than `batch_size` if the total number of samples is not divisible
+/// by it.
+pub fn load_batches(
+    batch_size: usize,
+) -> Vec<Vec<(Vec<usize>, Vec<usize>)>> {
+    let pairs = load_pairs();
+    pairs.chunks(batch_size).map(|c| c.to_vec()).collect()
+}
+
 /// Download the MNIST dataset into the local `data/` directory.
 ///
 /// This uses the `mnist` crate's built-in downloader which fetches the

--- a/src/train_backprop.rs
+++ b/src/train_backprop.rs
@@ -1,4 +1,4 @@
-use crate::data::{load_pairs, to_matrix, Vocab, START};
+use crate::data::{load_batches, to_matrix, Vocab, START};
 use crate::math;
 use crate::metrics::f1_score;
 use crate::optim::{Adam, SGD};
@@ -9,7 +9,7 @@ use indicatif::ProgressBar;
 // Tensor Backprop Training (simplified Adam hook)
 // now using Embedding => model_dim independent of vocab_size
 pub fn run(_opt: &str) {
-    let pairs = load_pairs();
+    let batches = load_batches(4);
     let vocab = Vocab::build();
     let vocab_size = vocab.itos.len();
 
@@ -34,26 +34,38 @@ pub fn run(_opt: &str) {
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for (src, tgt) in &pairs {
+        for batch in &batches {
             encoder.zero_grad();
             decoder.zero_grad();
+            let mut batch_loss = 0.0f32;
+            let mut batch_f1 = 0.0f32;
+            for (src, tgt) in batch {
+                // Encode source sentence
+                let enc_x = to_matrix(src, vocab_size);
+                let enc_out = encoder.forward_train(&enc_x);
 
-            // Encode source sentence
-            let enc_x = to_matrix(src, vocab_size);
-            let enc_out = encoder.forward_train(&enc_x);
+                // Decoder input uses teacher forcing (START + target[:-1])
+                let mut dec_in = vec![start_id];
+                dec_in.extend_from_slice(tgt);
+                let dec_x = to_matrix(&dec_in, vocab_size);
+                let logits = decoder.forward_train(&dec_x, &enc_out);
 
-            // Decoder input uses teacher forcing (START + target[:-1])
-            let mut dec_in = vec![start_id];
-            dec_in.extend_from_slice(tgt);
-            let dec_x = to_matrix(&dec_in, vocab_size);
-            let logits = decoder.forward_train(&dec_x, &enc_out);
+                let (loss, grad, preds) =
+                    math::softmax_cross_entropy(&logits, tgt, 1);
+                batch_loss += loss;
 
-            let (loss, grad, preds) = math::softmax_cross_entropy(&logits, tgt, 1);
-            last_loss = loss;
-
-            // Backward through decoder and encoder
-            let grad_enc = decoder.backward(&grad);
-            encoder.backward(&grad_enc);
+                // Backward through decoder and encoder
+                let grad_enc = decoder.backward(&grad);
+                encoder.backward(&grad_enc);
+                let f1 = f1_score(&preds, tgt);
+                batch_f1 += f1;
+            }
+            let bsz = batch.len() as f32;
+            batch_loss /= bsz;
+            let batch_f1_avg = batch_f1 / bsz;
+            last_loss = batch_loss;
+            f1_sum += batch_f1;
+            sample_cnt += bsz;
             let mut params = encoder.parameters();
             {
                 let dec_params = decoder.parameters();
@@ -64,11 +76,7 @@ pub fn run(_opt: &str) {
             } else {
                 adam.step(&mut params);
             }
-
-            let f1 = f1_score(&preds, tgt);
-            f1_sum += f1;
-            sample_cnt += 1.0;
-            println!("loss {loss:.4} f1 {f1:.4}");
+            println!("loss {batch_loss:.4} f1 {batch_f1_avg:.4}");
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));

--- a/src/transformer_t.rs
+++ b/src/transformer_t.rs
@@ -56,7 +56,8 @@ impl LinearT {
     /// gradient for the weights inside `self.grad`.
     pub fn backward(&mut self, grad_out: &Matrix) -> Matrix {
         let x_t = self.last_x.transpose();
-        self.grad = Matrix::matmul(&x_t, grad_out);
+        let grad_w = Matrix::matmul(&x_t, grad_out);
+        self.grad = self.grad.add(&grad_w);
         Matrix::matmul(grad_out, &self.w.data.transpose())
     }
 


### PR DESCRIPTION
## Summary
- Add `load_batches` helper to group MNIST pairs into mini-batches
- Accumulate gradients across batches in training scripts and linear layer
- Update training loops to optimize once per batch with aggregated loss

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aad33d2e50832fa3249fc1d0c279f1