### PR TITLE
Implement local learning updates

### DIFF
--- a/src/train_noprop.rs
+++ b/src/train_noprop.rs
@@ -1,7 +1,6 @@
 use crate::data::{load_pairs, to_matrix, Vocab};
 use crate::math::{self, Matrix};
 use crate::metrics::f1_score;
-use crate::optim::Adam;
 use crate::transformer_t::EncoderT;
 use crate::weights::save_model;
 use indicatif::ProgressBar;
@@ -14,11 +13,7 @@ pub fn run() {
     let model_dim = 64;
     let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
     let lr = 0.001;
-    let beta1 = 0.9;
-    let beta2 = 0.999;
-    let eps = 1e-8;
     let weight_decay = 0.0;
-    let mut optim = Adam::new(lr, beta1, beta2, eps, weight_decay);
 
     math::reset_matrix_ops();
     let epochs = 5;
@@ -29,9 +24,8 @@ pub fn run() {
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
         for (src, tgt) in &pairs {
-            encoder.zero_grad();
             let x = to_matrix(src, vocab_size);
-            let enc_out = encoder.forward_train(&x);
+            let enc_out = encoder.forward_local(&x);
 
             // encode target without affecting gradients and add noise
             let mut noisy = encoder.forward(&to_matrix(tgt, vocab_size));
@@ -39,26 +33,24 @@ pub fn run() {
                 *v += (rand::random::<f32>() - 0.5) * 0.1;
             }
 
-            // Mean squared error and gradient
-            let mut grad = Matrix::zeros(enc_out.rows, enc_out.cols);
+            // Mean squared error and error signal
+            let mut err = Matrix::zeros(enc_out.rows, enc_out.cols);
             let mut loss = 0.0f32;
             for i in 0..enc_out.data.len() {
                 let d = enc_out.data[i] - noisy.data.data[i];
                 loss += d * d;
-                grad.data[i] = 2.0 * d;
+                err.data[i] = d;
             }
             let n = enc_out.data.len() as f32;
             if n > 0.0 {
                 loss /= n;
-                for v in grad.data.iter_mut() {
+                for v in err.data.iter_mut() {
                     *v /= n;
                 }
             }
             last_loss = loss;
 
-            encoder.backward(&grad);
-            let mut params = encoder.parameters();
-            optim.step(&mut params);
+            encoder.local_update(&err, lr, weight_decay);
 
             let f1 = f1_score(&src[..tgt.len().min(src.len())], tgt);
             f1_sum += f1;


### PR DESCRIPTION
## Summary
- Add layer-local learning rule with random feedback matrices
- Enable per-layer updates without backprop storage
- Train `noprop` mode using local Hebbian updates instead of Adam

## Testing
- `cargo run -- noprop` *(fails: Unable to find path to images at data/train-images-idx3-ubyte)*

------
https://chatgpt.com/codex/tasks/task_e_68aae1d699dc832f89ffc8bc45871a1d