### PR TITLE
Simplify MNIST data loading

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -1,6 +1,14 @@
 use crate::autograd::Tensor;
-use crate::data::to_matrix;
+use crate::math::Matrix;
 use crate::models::DecoderT;
+
+fn to_matrix(seq: &[usize], vocab_size: usize) -> Matrix {
+    let mut m = Matrix::zeros(seq.len(), vocab_size);
+    for (i, &tok) in seq.iter().enumerate() {
+        m.set(i, tok, 1.0);
+    }
+    m
+}
 
 pub fn beam_search_decode(
     decoder: &DecoderT,

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,9 +1,17 @@
-use crate::data::{load_pairs, to_matrix, Vocab, END, START};
-use crate::decoding::beam_search_decode;
-use crate::math;
+use crate::autograd::Tensor;
+use crate::data::load_pairs;
+use crate::math::{self, Matrix};
 use crate::models::{DecoderT, EncoderT};
 use crate::weights::load_model;
 use rand::Rng;
+
+fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
+    let mut m = Matrix::zeros(seq.len(), vocab_size);
+    for (i, &tok) in seq.iter().enumerate() {
+        m.set(i, tok as usize, 1.0);
+    }
+    m
+}
 
 pub fn run() {
     // pick a random image from the MNIST training pairs
@@ -12,10 +20,7 @@ pub fn run() {
     let idx = rng.gen_range(0..pairs.len());
     let (src, tgt) = &pairs[idx];
 
-    let vocab = Vocab::build();
-    let vocab_size = vocab.itos.len();
-    let start_id = *vocab.stoi.get(START).unwrap();
-    let end_id = *vocab.stoi.get(END).unwrap();
+    let vocab_size = 256;
 
     let model_dim = 64;
     let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
@@ -27,21 +32,24 @@ pub fn run() {
     let enc_x = to_matrix(src, vocab_size);
     let enc_out = encoder.forward(&enc_x);
 
-    // use beam search for better predictions
-    let out_ids = beam_search_decode(&decoder, &enc_out, start_id, end_id, vocab_size, 50, 3);
-    let pred_id = out_ids
-        .into_iter()
-        .find(|&id| id != start_id && id != end_id);
-    let prediction = pred_id
-        .map(|id| vocab.itos[id].clone())
-        .unwrap_or_else(|| "[no prediction]".to_string());
-    let actual = tgt
-        .first()
-        .map(|&id| vocab.itos[id].clone())
-        .unwrap_or_else(|| "[unknown]".to_string());
+    let dec_in = vec![0u8];
+    let dec_x = to_matrix(&dec_in, vocab_size);
+    let logits = decoder.forward(&Tensor::from_matrix(dec_x), &enc_out);
+    let probs = Tensor::softmax(&logits);
+
+    let mut best_tok = 0usize;
+    let mut best_val = f32::NEG_INFINITY;
+    for t in 0..vocab_size {
+        let p = probs.data.get(0, t);
+        if p > best_val {
+            best_val = p;
+            best_tok = t;
+        }
+    }
+
     println!(
-        "{{\"actual\":\"{}\", \"prediction\":\"{}\"}}",
-        actual, prediction
+        "{{\"actual\":{}, \"prediction\":{}}}",
+        tgt, best_tok
     );
     println!("Total matrix ops: {}", math::matrix_ops_count());
 }


### PR DESCRIPTION
## Summary
- Drop start/end tokens, vocabulary, and one-hot utilities from data module
- Load MNIST samples as raw pixel vectors with a single label
- Update batch loader and training/prediction code for `(Vec<u8>, usize)` pairs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab15cf317c832fb3ef342c6f386d76