### PR TITLE
Fix one-hot encoding in compare example

### DIFF
--- a/src/bin/compare.rs
+++ b/src/bin/compare.rs
@@ -34,14 +34,16 @@ fn train_backprop(epochs: usize) -> (f32, usize) {
             let mut batch_f1 = 0.0f32;
             for (src, tgt) in batch {
                 let tgt = *tgt;
-                let enc_x = Matrix::from_vec(
-                    src.len(),
-                    1,
-                    src.iter().map(|&v| v as f32).collect(),
-                );
+                // one-hot encode source sequence for embedding layer
+                let mut enc_x = Matrix::zeros(src.len(), vocab_size);
+                for (i, &tok) in src.iter().enumerate() {
+                    enc_x.set(i, tok as usize, 1.0);
+                }
                 let enc_out = encoder.forward_train(&enc_x);
 
-                let dec_x = Matrix::from_vec(1, 1, vec![tgt as f32]);
+                // one-hot encode target token for decoder input
+                let mut dec_x = Matrix::zeros(1, vocab_size);
+                dec_x.set(0, tgt as usize, 1.0);
                 let logits = decoder.forward_train(&dec_x, &enc_out);
 
                 let (loss, grad, preds) = math::softmax_cross_entropy(&logits, &[tgt], 0);
@@ -99,14 +101,17 @@ fn train_noprop(epochs: usize) -> (f32, usize) {
             for (src, tgt) in batch {
                 let tgt = *tgt;
                 let len = 1usize;
-                let x = Matrix::from_vec(
-                    len,
-                    1,
-                    src[..len].iter().map(|&v| v as f32).collect(),
-                );
+                // one-hot encode the source token for the embedding layer
+                let mut x = Matrix::zeros(len, vocab_size);
+                for (i, &tok) in src[..len].iter().enumerate() {
+                    x.set(i, tok as usize, 1.0);
+                }
                 let enc_out = encoder.forward_local(&x);
 
-                let mut noisy = encoder.forward(&Matrix::from_vec(1, 1, vec![tgt as f32]));
+                // encode target without affecting gradients and add noise
+                let mut tgt_mat = Matrix::zeros(1, vocab_size);
+                tgt_mat.set(0, tgt as usize, 1.0);
+                let mut noisy = encoder.forward(&tgt_mat);
                 for v in &mut noisy.data.data {
                     *v += (rand::random::<f32>() - 0.5) * 0.1;
                 }


### PR DESCRIPTION
## Summary
- Encode source sequences and decoder inputs as one-hot matrices in the `compare` example

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab25426994832f86a1bd2f15f2c281