### PR TITLE
Add simple CNN model with CLI selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ pixel values. A light 3x3 mean convolution is applied to each image during
 loading to provide basic convolutional preprocessing. The training modes
 (standard backpropagation, NoProp, and an ELMo-inspired method) now all use
 these image/label pairs.
+
+The project now also includes a very small convolutional neural network
+alongside the original transformer model.  When running predictions you can
+choose the model via the command line:
+
+```
+./run.sh predict          # uses the CNN (default)
+./run.sh predict transformer
+```

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,8 @@ case "$1" in
     cargo run --bin main -- download
     ;;
   predict)
-    cargo run --bin main -- predict
+    shift
+    cargo run --bin main -- predict "$@"
     ;;
   train-backprop)
     cargo run --bin train_backprop

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -10,7 +10,10 @@ fn main() {
     }
 
     match args[1].as_str() {
-        "predict" => predict::run(),
+        "predict" => {
+            let model = args.get(2).map(|s| s.as_str());
+            predict::run(model);
+        }
         "download" => data::download_mnist(),
         other => eprintln!("Unknown mode {}", other),
     }

--- a/src/models/cnn.rs
+++ b/src/models/cnn.rs
@@ -1,0 +1,82 @@
+use crate::math::Matrix;
+use rand::Rng;
+
+/// A very small convolutional network used for demonstration purposes.
+///
+/// The network applies a single 3x3 convolution with ReLU activation
+/// followed by a linear layer that maps the flattened feature map to the
+/// desired number of classes.
+pub struct SimpleCNN {
+    kernel: [[f32; 3]; 3],
+    fc: Matrix,
+    bias: Vec<f32>,
+}
+
+impl SimpleCNN {
+    /// Create a new CNN with random weights for the fully connected layer.
+    /// The convolution kernel is initialised with a simple mean blur.
+    pub fn new(num_classes: usize) -> Self {
+        // 3x3 mean kernel
+        let kernel = [[1.0 / 9.0; 3]; 3];
+        let mut rng = rand::thread_rng();
+        let mut w = Vec::with_capacity(28 * 28 * num_classes);
+        for _ in 0..(28 * 28 * num_classes) {
+            w.push(rng.gen_range(-0.01..0.01));
+        }
+        let fc = Matrix::from_vec(28 * 28, num_classes, w);
+        let bias = vec![0.0; num_classes];
+        Self { kernel, fc, bias }
+    }
+
+    fn convolve(&self, img: &[u8]) -> Vec<f32> {
+        let width = 28;
+        let height = 28;
+        let mut out = vec![0f32; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                let mut acc = 0.0f32;
+                for ky in 0..3 {
+                    for kx in 0..3 {
+                        let ix = x as isize + kx as isize - 1;
+                        let iy = y as isize + ky as isize - 1;
+                        if ix >= 0 && ix < width as isize && iy >= 0 && iy < height as isize {
+                            let idx = iy as usize * width + ix as usize;
+                            acc += img[idx] as f32 * self.kernel[ky][kx];
+                        }
+                    }
+                }
+                if acc < 0.0 {
+                    acc = 0.0; // ReLU
+                }
+                out[y * width + x] = acc;
+            }
+        }
+        out
+    }
+
+    /// Predict the class for a single image.
+    pub fn predict(&self, img: &[u8]) -> usize {
+        let feat = self.convolve(img); // 28x28 -> 784 features
+        let rows = self.fc.rows;
+        let cols = self.fc.cols;
+        let mut logits = vec![0f32; cols];
+        for c in 0..cols {
+            let mut sum = self.bias[c];
+            for r in 0..rows {
+                sum += feat[r] * self.fc.get(r, c);
+            }
+            logits[c] = sum;
+        }
+        // Argmax over logits
+        let mut best = 0usize;
+        let mut best_val = f32::NEG_INFINITY;
+        for (i, &v) in logits.iter().enumerate() {
+            if v > best_val {
+                best_val = v;
+                best = i;
+            }
+        }
+        best
+    }
+}
+

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,8 @@
 pub mod encoder;
 pub mod decoder;
+pub mod cnn;
 
 pub use encoder::{EncoderLayerT, EncoderT};
 pub use decoder::{DecoderLayerT, DecoderT};
+pub use cnn::SimpleCNN;
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,7 +1,7 @@
 use crate::autograd::Tensor;
 use crate::data::load_pairs;
 use crate::math::{self, Matrix};
-use crate::models::{DecoderT, EncoderT};
+use crate::models::{DecoderT, EncoderT, SimpleCNN};
 use crate::weights::load_model;
 use rand::Rng;
 
@@ -13,47 +13,56 @@ fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
     m
 }
 
-pub fn run() {
+pub fn run(model: Option<&str>) {
     // pick a random image from the MNIST training pairs
     let pairs = load_pairs();
     let mut rng = rand::thread_rng();
     let idx = rng.gen_range(0..pairs.len());
     let (src, tgt) = &pairs[idx];
 
-    let vocab_size = 256;
+    match model.unwrap_or("cnn") {
+        "transformer" => {
+            let vocab_size = 256;
+            let model_dim = 64;
+            let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
+            let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256);
 
-    let model_dim = 64;
-    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
-    let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256);
+            load_model("model.json", &mut encoder, &mut decoder);
 
-    load_model("model.json", &mut encoder, &mut decoder);
+            math::reset_matrix_ops();
+            let enc_x = to_matrix(src, vocab_size);
+            let enc_out = encoder.forward(&enc_x);
 
-    math::reset_matrix_ops();
-    let enc_x = to_matrix(src, vocab_size);
-    let enc_out = encoder.forward(&enc_x);
+            // Average encoder activations across the sequence
+            let mut avg = Matrix::zeros(1, enc_out.data.cols);
+            for c in 0..enc_out.data.cols {
+                let mut sum = 0f32;
+                for r in 0..enc_out.data.rows {
+                    sum += enc_out.data.get(r, c);
+                }
+                avg.set(0, c, sum / enc_out.data.rows as f32);
+            }
 
-    // Average encoder activations across the sequence
-    let mut avg = Matrix::zeros(1, enc_out.data.cols);
-    for c in 0..enc_out.data.cols {
-        let mut sum = 0f32;
-        for r in 0..enc_out.data.rows {
-            sum += enc_out.data.get(r, c);
+            let probs = Tensor::softmax(&Tensor::from_matrix(avg));
+
+            let mut best_tok = 0usize;
+            let mut best_val = f32::NEG_INFINITY;
+            for t in 0..probs.data.cols {
+                let p = probs.data.get(0, t);
+                if p > best_val {
+                    best_val = p;
+                    best_tok = t;
+                }
+            }
+
+            println!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
+            println!("Total matrix ops: {}", math::matrix_ops_count());
         }
-        avg.set(0, c, sum / enc_out.data.rows as f32);
-    }
-
-    let probs = Tensor::softmax(&Tensor::from_matrix(avg));
-
-    let mut best_tok = 0usize;
-    let mut best_val = f32::NEG_INFINITY;
-    for t in 0..probs.data.cols {
-        let p = probs.data.get(0, t);
-        if p > best_val {
-            best_val = p;
-            best_tok = t;
+        _ => {
+            // default CNN
+            let cnn = SimpleCNN::new(10);
+            let pred = cnn.predict(src);
+            println!("{{\"actual\":{}, \"prediction\":{}}}", tgt, pred);
         }
     }
-
-    println!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
-    println!("Total matrix ops: {}", math::matrix_ops_count());
 }


### PR DESCRIPTION
## Summary
- introduce a lightweight `SimpleCNN` with a single convolution + linear layer
- allow `predict` to switch between CNN (default) and transformer models
- expose model choice via command line and document usage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3fc71008832f9216072563a41e3c