### PR TITLE
Enable training for CNN or transformer models

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop}" >&2
+  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop} [model]" >&2
   exit 1
 }
 
@@ -18,15 +18,18 @@ case "$1" in
     shift
     cargo run --bin main -- predict "$@"
     ;;
-  train-backprop)
-    cargo run --bin train_backprop
-    ;;
-  train-elmo)
-    cargo run --bin train_elmo
-    ;;
-  train-noprop)
-    cargo run --bin train_noprop
-    ;;
+    train-backprop)
+      shift
+      cargo run --bin train_backprop "$@"
+      ;;
+    train-elmo)
+      shift
+      cargo run --bin train_elmo "$@"
+      ;;
+    train-noprop)
+      shift
+      cargo run --bin train_noprop "$@"
+      ;;
   *)
     usage
     ;;

--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -7,10 +7,16 @@ use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::{DecoderT, EncoderT};
 use vanillanoprop::optim::{Adam, SGD};
 use vanillanoprop::weights::save_model;
+use vanillanoprop::train_cnn;
 
 fn main() {
-    let opt = env::args().nth(1).unwrap_or_else(|| "sgd".to_string());
-    run(&opt);
+    let model = env::args().nth(1).unwrap_or_else(|| "transformer".to_string());
+    let opt = env::args().nth(2).unwrap_or_else(|| "sgd".to_string());
+    if model == "cnn" {
+        train_cnn::run(&opt);
+    } else {
+        run(&opt);
+    }
 }
 
 // Tensor Backprop Training (simplified Adam hook)

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use indicatif::ProgressBar;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::math::{self, Matrix};
@@ -5,9 +7,15 @@ use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::EncoderT;
 use vanillanoprop::optim::Adam;
 use vanillanoprop::weights::save_model;
+use vanillanoprop::train_cnn;
 
 fn main() {
-    run();
+    let model = env::args().nth(1).unwrap_or_else(|| "transformer".to_string());
+    if model == "cnn" {
+        train_cnn::run("sgd");
+    } else {
+        run();
+    }
 }
 
 fn run() {

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -1,12 +1,20 @@
+use std::env;
+
 use indicatif::ProgressBar;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::EncoderT;
 use vanillanoprop::weights::save_model;
+use vanillanoprop::train_cnn;
 
 fn main() {
-    run();
+    let model = env::args().nth(1).unwrap_or_else(|| "transformer".to_string());
+    if model == "cnn" {
+        train_cnn::run("sgd");
+    } else {
+        run();
+    }
 }
 
 fn run() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod optim;
 pub mod positional;
 pub mod predict;
 pub mod weights;
+pub mod train_cnn;

--- a/src/models/cnn.rs
+++ b/src/models/cnn.rs
@@ -54,8 +54,8 @@ impl SimpleCNN {
         out
     }
 
-    /// Predict the class for a single image.
-    pub fn predict(&self, img: &[u8]) -> usize {
+    /// Forward pass returning the convolution features and logits.
+    pub fn forward(&self, img: &[u8]) -> (Vec<f32>, Vec<f32>) {
         let feat = self.convolve(img); // 28x28 -> 784 features
         let rows = self.fc.rows;
         let cols = self.fc.cols;
@@ -67,6 +67,12 @@ impl SimpleCNN {
             }
             logits[c] = sum;
         }
+        (feat, logits)
+    }
+
+    /// Predict the class for a single image.
+    pub fn predict(&self, img: &[u8]) -> usize {
+        let (_feat, logits) = self.forward(img);
         // Argmax over logits
         let mut best = 0usize;
         let mut best_val = f32::NEG_INFINITY;
@@ -77,6 +83,16 @@ impl SimpleCNN {
             }
         }
         best
+    }
+
+    /// Access immutable parameters.
+    pub fn parameters(&self) -> (&Matrix, &Vec<f32>) {
+        (&self.fc, &self.bias)
+    }
+
+    /// Access mutable parameters.
+    pub fn parameters_mut(&mut self) -> (&mut Matrix, &mut Vec<f32>) {
+        (&mut self.fc, &mut self.bias)
     }
 }
 

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,8 +1,8 @@
 use crate::autograd::Tensor;
 use crate::data::load_pairs;
 use crate::math::{self, Matrix};
-use crate::models::{DecoderT, EncoderT, SimpleCNN};
-use crate::weights::load_model;
+use crate::models::{DecoderT, EncoderT};
+use crate::weights::{load_cnn, load_model};
 use rand::Rng;
 
 fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
@@ -60,7 +60,7 @@ pub fn run(model: Option<&str>) {
         }
         _ => {
             // default CNN
-            let cnn = SimpleCNN::new(10);
+            let cnn = load_cnn("cnn.json", 10);
             let pred = cnn.predict(src);
             println!("{{\"actual\":{}, \"prediction\":{}}}", tgt, pred);
         }

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -1,0 +1,108 @@
+use indicatif::ProgressBar;
+
+use crate::data::load_batches;
+use crate::math;
+use crate::metrics::f1_score;
+use crate::models::SimpleCNN;
+use crate::weights::save_cnn;
+
+/// Train a [`SimpleCNN`] on the MNIST data using a basic SGD loop.
+///
+/// `opt` is kept for parity with other training binaries but currently only
+/// SGD is implemented.
+pub fn run(opt: &str) {
+    let _ = opt; // optimizer placeholder
+
+    let batches = load_batches(4);
+    let mut cnn = SimpleCNN::new(10);
+
+    let lr = 0.01f32;
+    let epochs = 5;
+
+    math::reset_matrix_ops();
+    let pb = ProgressBar::new(epochs as u64);
+    let mut best_f1 = f32::NEG_INFINITY;
+
+    for epoch in 0..epochs {
+        let mut last_loss = 0.0f32;
+        let mut f1_sum = 0.0f32;
+        let mut sample_cnt = 0.0f32;
+
+        for batch in &batches {
+            let mut batch_loss = 0.0f32;
+            let mut batch_f1 = 0.0f32;
+
+            for (img, tgt) in batch {
+                let (feat, logits) = cnn.forward(img);
+
+                // Softmax
+                let max = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                let mut exp_sum = 0.0f32;
+                let mut probs = vec![0f32; logits.len()];
+                for (i, &v) in logits.iter().enumerate() {
+                    let e = (v - max).exp();
+                    probs[i] = e;
+                    exp_sum += e;
+                }
+                for p in &mut probs {
+                    *p /= exp_sum;
+                }
+
+                let loss = -probs[*tgt as usize].ln();
+                batch_loss += loss;
+
+                // Gradient of cross-entropy w.r.t logits
+                let mut grad_logits = probs.clone();
+                grad_logits[*tgt as usize] -= 1.0;
+
+                // Update weights
+                let (fc, bias) = cnn.parameters_mut();
+                let rows = fc.rows;
+                let cols = fc.cols;
+                for c in 0..cols {
+                    let g = grad_logits[c];
+                    bias[c] -= lr * g;
+                    for r in 0..rows {
+                        let val = fc.get(r, c) - lr * g * feat[r];
+                        fc.set(r, c, val);
+                    }
+                }
+
+                // Prediction for metrics
+                let mut best = 0usize;
+                let mut best_val = f32::NEG_INFINITY;
+                for (i, &v) in probs.iter().enumerate() {
+                    if v > best_val {
+                        best_val = v;
+                        best = i;
+                    }
+                }
+                batch_f1 += f1_score(&[best], &[*tgt as usize]);
+            }
+
+            let bsz = batch.len() as f32;
+            batch_loss /= bsz;
+            let batch_f1_avg = batch_f1 / bsz;
+            last_loss = batch_loss;
+            f1_sum += batch_f1;
+            sample_cnt += bsz;
+            println!("loss {batch_loss:.4} f1 {batch_f1_avg:.4}");
+        }
+
+        let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
+        pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
+        pb.inc(1);
+
+        if avg_f1 > best_f1 {
+            println!("Checkpoint saved at epoch {epoch}: avg F1 improved to {avg_f1:.4}");
+            best_f1 = avg_f1;
+            save_cnn("checkpoint_cnn.json", &cnn);
+        }
+    }
+
+    pb.finish_with_message("training done");
+
+    println!("Total matrix ops: {}", math::matrix_ops_count());
+    save_cnn("cnn.json", &cnn);
+}
+


### PR DESCRIPTION
## Summary
- allow choosing CNN or transformer in training scripts and run.sh
- implement a basic SimpleCNN training loop with weight persistence
- load saved CNN weights during prediction

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab428e358c832f8fb83726d200dddc