### PR TITLE
Count CNN matrix ops

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -10,7 +10,7 @@ pub fn matrix_ops_count() -> usize {
     MATRIX_OPS.load(Ordering::SeqCst)
 }
 
-fn inc_ops() {
+pub(crate) fn inc_ops() {
     MATRIX_OPS.fetch_add(1, Ordering::SeqCst);
 }
 

--- a/src/models/cnn.rs
+++ b/src/models/cnn.rs
@@ -1,4 +1,4 @@
-use crate::math::Matrix;
+use crate::math::{self, Matrix};
 use rand::Rng;
 
 /// A very small convolutional network used for demonstration purposes.
@@ -29,6 +29,7 @@ impl SimpleCNN {
     }
 
     fn convolve(&self, img: &[u8]) -> Vec<f32> {
+        math::inc_ops();
         let width = 28;
         let height = 28;
         let mut out = vec![0f32; width * height];
@@ -57,6 +58,7 @@ impl SimpleCNN {
     /// Forward pass returning the convolution features and logits.
     pub fn forward(&self, img: &[u8]) -> (Vec<f32>, Vec<f32>) {
         let feat = self.convolve(img); // 28x28 -> 784 features
+        math::inc_ops();
         let rows = self.fc.rows;
         let cols = self.fc.cols;
         let mut logits = vec![0f32; cols];

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -67,6 +67,7 @@ pub fn run(opt: &str) {
                         fc.set(r, c, val);
                     }
                 }
+                math::inc_ops();
 
                 // Prediction for metrics
                 let mut best = 0usize;


### PR DESCRIPTION
## Summary
- expose a crate-internal helper to increment the matrix op counter
- track convolution, fully connected, and update steps in the simple CNN

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab479a2168832fa89ffcabd8bee716