### PR TITLE
Add modular ReLU and Sigmoid activations

### DIFF
--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -3,10 +3,12 @@ pub mod embedding;
 pub mod feed_forward;
 pub mod multi_head_attention;
 pub mod layer;
+pub mod relu;
+pub mod sigmoid;
 
 pub use linear::LinearT;
 pub use embedding::EmbeddingT;
-pub use feed_forward::FeedForwardT;
+pub use feed_forward::{Activation, FeedForwardT};
 pub use multi_head_attention::MultiHeadAttentionT;
 pub use layer::Layer;
 

--- a/src/layers/relu.rs
+++ b/src/layers/relu.rs
@@ -1,0 +1,32 @@
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// Apply ReLU activation in place on a tensor.
+pub fn forward_tensor(t: &mut Tensor) {
+    for v in t.data.data.iter_mut() {
+        if *v < 0.0 {
+            *v = 0.0;
+        }
+    }
+}
+
+/// Apply ReLU activation in place on a matrix and return a mask for backward.
+pub fn forward_matrix(m: &mut Matrix) -> Vec<f32> {
+    let mut mask = vec![0.0; m.data.len()];
+    for (i, v) in m.data.iter_mut().enumerate() {
+        if *v < 0.0 {
+            *v = 0.0;
+        } else {
+            mask[i] = 1.0;
+        }
+    }
+    mask
+}
+
+/// Apply the stored ReLU mask to the gradient matrix.
+pub fn backward(grad: &mut Matrix, mask: &[f32]) {
+    for (g, &m) in grad.data.iter_mut().zip(mask.iter()) {
+        *g *= m;
+    }
+}
+

--- a/src/layers/sigmoid.rs
+++ b/src/layers/sigmoid.rs
@@ -1,0 +1,24 @@
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// Apply sigmoid activation in place on a tensor.
+pub fn forward_tensor(t: &mut Tensor) {
+    for v in t.data.data.iter_mut() {
+        *v = 1.0 / (1.0 + (-*v).exp());
+    }
+}
+
+/// Apply sigmoid activation in place on a matrix.
+pub fn forward_matrix(m: &mut Matrix) {
+    for v in m.data.iter_mut() {
+        *v = 1.0 / (1.0 + (-*v).exp());
+    }
+}
+
+/// Multiply gradient with derivative of sigmoid using activated values.
+pub fn backward(grad: &mut Matrix, activated: &Matrix) {
+    for (g, &h) in grad.data.iter_mut().zip(activated.data.iter()) {
+        *g *= h * (1.0 - h);
+    }
+}
+

--- a/src/models/decoder.rs
+++ b/src/models/decoder.rs
@@ -1,4 +1,4 @@
-use crate::layers::{EmbeddingT, FeedForwardT, Layer, LinearT, MultiHeadAttentionT};
+use crate::layers::{Activation, EmbeddingT, FeedForwardT, Layer, LinearT, MultiHeadAttentionT};
 use crate::math::Matrix;
 use crate::tensor::Tensor;
 
@@ -15,7 +15,7 @@ impl DecoderLayerT {
         Self {
             self_attn: Box::new(MultiHeadAttentionT::new(dim)),
             enc_dec_attn: Box::new(MultiHeadAttentionT::new(dim)),
-            ff: Box::new(FeedForwardT::new(dim, hidden, true)),
+            ff: Box::new(FeedForwardT::new(dim, hidden, Activation::ReLU)),
             h1: Matrix::zeros(0, 0),
             ctx: Matrix::zeros(0, 0),
         }

--- a/src/models/encoder.rs
+++ b/src/models/encoder.rs
@@ -1,4 +1,4 @@
-use crate::layers::{EmbeddingT, FeedForwardT, Layer, LinearT, MultiHeadAttentionT};
+use crate::layers::{Activation, EmbeddingT, FeedForwardT, Layer, LinearT, MultiHeadAttentionT};
 use crate::math::Matrix;
 use crate::positional::positional_encoding;
 use crate::tensor::Tensor;
@@ -13,7 +13,7 @@ impl EncoderLayerT {
     pub fn new(dim: usize, hidden: usize) -> Self {
         Self {
             attn: Box::new(MultiHeadAttentionT::new(dim)),
-            ff: Box::new(FeedForwardT::new(dim, hidden, true)),
+            ff: Box::new(FeedForwardT::new(dim, hidden, Activation::ReLU)),
             attn_out: Matrix::zeros(0, 0),
         }
     }


### PR DESCRIPTION
## Summary
- extract ReLU logic into its own helper module and add a matching Sigmoid module
- allow FeedForwardT to select between ReLU, Sigmoid or no activation through an `Activation` enum
- adjust encoder and decoder constructors to use the new activation enum

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acbb6cc0f0832fbeba3593aabe2438