### PR TITLE
Add activation layers and make models configurable

### DIFF
--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -2,16 +2,19 @@ use std::env;
 
 use indicatif::ProgressBar;
 use vanillanoprop::data::load_batches;
+use vanillanoprop::layers::Activation;
 use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::memory;
 use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::{DecoderT, EncoderT};
 use vanillanoprop::optim::{Adam, SGD};
-use vanillanoprop::weights::save_model;
 use vanillanoprop::train_cnn;
-use vanillanoprop::memory;
+use vanillanoprop::weights::save_model;
 
 fn main() {
-    let model = env::args().nth(1).unwrap_or_else(|| "transformer".to_string());
+    let model = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "transformer".to_string());
     let opt = env::args().nth(2).unwrap_or_else(|| "sgd".to_string());
     if model == "cnn" {
         train_cnn::run(&opt);
@@ -27,8 +30,8 @@ fn run(opt: &str) {
     let vocab_size = 256;
 
     let model_dim = 64;
-    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
-    let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256);
+    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
+    let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
 
     let lr = 0.001;
     let beta1 = 0.9;
@@ -105,7 +108,10 @@ fn run(opt: &str) {
 
     println!("Total matrix ops: {}", math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    println!("Max memory usage: {:.2} MB", peak as f64 / (1024.0 * 1024.0));
+    println!(
+        "Max memory usage: {:.2} MB",
+        peak as f64 / (1024.0 * 1024.0)
+    );
 
     // Save trained weights
     save_model("model.json", &mut encoder, Some(&mut decoder));

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -2,16 +2,19 @@ use std::env;
 
 use indicatif::ProgressBar;
 use vanillanoprop::data::load_batches;
+use vanillanoprop::layers::Activation;
 use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::memory;
 use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::EncoderT;
 use vanillanoprop::optim::Adam;
-use vanillanoprop::weights::save_model;
 use vanillanoprop::train_cnn;
-use vanillanoprop::memory;
+use vanillanoprop::weights::save_model;
 
 fn main() {
-    let model = env::args().nth(1).unwrap_or_else(|| "transformer".to_string());
+    let model = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "transformer".to_string());
     if model == "cnn" {
         train_cnn::run("sgd");
     } else {
@@ -25,7 +28,7 @@ fn run() {
 
     // With embedding → model_dim separate
     let model_dim = 64;
-    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 128);
+    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 128, Activation::ReLU);
     let lr = 0.001;
     let beta1 = 0.9;
     let beta2 = 0.999;
@@ -83,7 +86,10 @@ fn run() {
 
     println!("Total matrix ops: {}", math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    println!("Max memory usage: {:.2} MB", peak as f64 / (1024.0 * 1024.0));
+    println!(
+        "Max memory usage: {:.2} MB",
+        peak as f64 / (1024.0 * 1024.0)
+    );
 
     save_model("model.json", &mut encoder, None);
 }

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -2,15 +2,18 @@ use std::env;
 
 use indicatif::ProgressBar;
 use vanillanoprop::data::load_batches;
+use vanillanoprop::layers::Activation;
 use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::memory;
 use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::EncoderT;
-use vanillanoprop::weights::save_model;
 use vanillanoprop::train_cnn;
-use vanillanoprop::memory;
+use vanillanoprop::weights::save_model;
 
 fn main() {
-    let model = env::args().nth(1).unwrap_or_else(|| "transformer".to_string());
+    let model = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "transformer".to_string());
     if model == "cnn" {
         train_cnn::run("sgd");
     } else {
@@ -23,7 +26,7 @@ fn run() {
     let vocab_size = 256;
 
     let model_dim = 64;
-    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
+    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
     let lr = 0.001;
 
     math::reset_matrix_ops();
@@ -100,7 +103,10 @@ fn run() {
 
     println!("Total matrix ops: {}", math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    println!("Max memory usage: {:.2} MB", peak as f64 / (1024.0 * 1024.0));
+    println!(
+        "Max memory usage: {:.2} MB",
+        peak as f64 / (1024.0 * 1024.0)
+    );
 
     save_model("model.json", &mut encoder, None);
 }

--- a/src/layers/leaky_relu.rs
+++ b/src/layers/leaky_relu.rs
@@ -1,0 +1,34 @@
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+const SLOPE: f32 = 0.01;
+
+/// Apply leaky ReLU activation in place on a tensor.
+pub fn forward_tensor(t: &mut Tensor) {
+    for v in t.data.data.iter_mut() {
+        if *v < 0.0 {
+            *v *= SLOPE;
+        }
+    }
+}
+
+/// Apply leaky ReLU activation in place on a matrix and return derivative mask.
+pub fn forward_matrix(m: &mut Matrix) -> Vec<f32> {
+    let mut mask = vec![0.0; m.data.len()];
+    for (i, v) in m.data.iter_mut().enumerate() {
+        if *v < 0.0 {
+            *v *= SLOPE;
+            mask[i] = SLOPE;
+        } else {
+            mask[i] = 1.0;
+        }
+    }
+    mask
+}
+
+/// Apply derivative mask to gradient matrix.
+pub fn backward(grad: &mut Matrix, mask: &[f32]) {
+    for (g, &m) in grad.data.iter_mut().zip(mask.iter()) {
+        *g *= m;
+    }
+}

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,16 +1,19 @@
-pub mod linear;
 pub mod embedding;
 pub mod feed_forward;
-pub mod multi_head_attention;
 pub mod layer;
+pub mod leaky_relu;
+pub mod linear;
+pub mod multi_head_attention;
+pub mod pooling;
 pub mod relu;
 pub mod sigmoid;
-pub mod pooling;
+pub mod softmax;
+pub mod tanh;
 
-pub use linear::LinearT;
 pub use embedding::EmbeddingT;
 pub use feed_forward::{Activation, FeedForwardT};
-pub use multi_head_attention::MultiHeadAttentionT;
 pub use layer::Layer;
+pub use linear::LinearT;
+pub use multi_head_attention::MultiHeadAttentionT;
 pub use pooling::{avg_pool2d, avg_pool2d_backward, max_pool2d, max_pool2d_backward};
-
+pub use softmax::SoftmaxT;

--- a/src/layers/softmax.rs
+++ b/src/layers/softmax.rs
@@ -1,0 +1,79 @@
+use super::layer::Layer;
+use super::linear::LinearT;
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// Softmax activation layer without parameters.
+pub struct SoftmaxT {
+    out: Matrix,
+}
+
+impl SoftmaxT {
+    pub fn new() -> Self {
+        Self {
+            out: Matrix::zeros(0, 0),
+        }
+    }
+
+    fn forward_internal(x: &Matrix) -> Matrix {
+        x.softmax()
+    }
+
+    fn backward_internal(&self, grad_out: &Matrix) -> Matrix {
+        let mut grad = Matrix::zeros(grad_out.rows, grad_out.cols);
+        for r in 0..grad_out.rows {
+            let row_start = r * grad_out.cols;
+            let row_grad = &grad_out.data[row_start..row_start + grad_out.cols];
+            let row_out = &self.out.data[row_start..row_start + grad_out.cols];
+            let mut dot = 0.0;
+            for c in 0..grad_out.cols {
+                dot += row_grad[c] * row_out[c];
+            }
+            for c in 0..grad_out.cols {
+                grad.data[row_start + c] = row_out[c] * (row_grad[c] - dot);
+            }
+        }
+        grad
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Tensor {
+        let data = Self::forward_internal(&x.data);
+        Tensor::from_matrix(data)
+    }
+
+    pub fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        let out = Self::forward_internal(x);
+        self.out = out.clone();
+        out
+    }
+
+    pub fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        self.backward_internal(grad_out)
+    }
+}
+
+impl Layer for SoftmaxT {
+    fn forward(&self, x: &Tensor) -> Tensor {
+        SoftmaxT::forward(self, x)
+    }
+
+    fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        SoftmaxT::forward_train(self, x)
+    }
+
+    fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        SoftmaxT::backward(self, grad_out)
+    }
+
+    fn zero_grad(&mut self) {}
+
+    fn fa_update(&mut self, grad_out: &Matrix, _lr: f32) -> Matrix {
+        self.backward_internal(grad_out)
+    }
+
+    fn adam_step(&mut self, _lr: f32, _beta1: f32, _beta2: f32, _eps: f32, _weight_decay: f32) {}
+
+    fn parameters(&mut self) -> Vec<&mut LinearT> {
+        Vec::new()
+    }
+}

--- a/src/layers/tanh.rs
+++ b/src/layers/tanh.rs
@@ -1,0 +1,23 @@
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// Apply tanh activation in place on a tensor.
+pub fn forward_tensor(t: &mut Tensor) {
+    for v in t.data.data.iter_mut() {
+        *v = v.tanh();
+    }
+}
+
+/// Apply tanh activation in place on a matrix.
+pub fn forward_matrix(m: &mut Matrix) {
+    for v in m.data.iter_mut() {
+        *v = v.tanh();
+    }
+}
+
+/// Multiply gradient with derivative of tanh using activated values.
+pub fn backward(grad: &mut Matrix, activated: &Matrix) {
+    for (g, &h) in grad.data.iter_mut().zip(activated.data.iter()) {
+        *g *= 1.0 - h * h;
+    }
+}

--- a/src/models/decoder.rs
+++ b/src/models/decoder.rs
@@ -11,11 +11,11 @@ pub struct DecoderLayerT {
 }
 
 impl DecoderLayerT {
-    pub fn new(dim: usize, hidden: usize) -> Self {
+    pub fn new(dim: usize, hidden: usize, activation: Activation) -> Self {
         Self {
             self_attn: Box::new(MultiHeadAttentionT::new(dim)),
             enc_dec_attn: Box::new(MultiHeadAttentionT::new(dim)),
-            ff: Box::new(FeedForwardT::new(dim, hidden, Activation::ReLU)),
+            ff: Box::new(FeedForwardT::new(dim, hidden, activation)),
             h1: Matrix::zeros(0, 0),
             ctx: Matrix::zeros(0, 0),
         }
@@ -88,10 +88,16 @@ pub struct DecoderT {
 }
 
 impl DecoderT {
-    pub fn new(n: usize, vocab_size: usize, model_dim: usize, hidden: usize) -> Self {
+    pub fn new(
+        n: usize,
+        vocab_size: usize,
+        model_dim: usize,
+        hidden: usize,
+        activation: Activation,
+    ) -> Self {
         let mut v = Vec::new();
         for _ in 0..n {
-            v.push(DecoderLayerT::new(model_dim, hidden));
+            v.push(DecoderLayerT::new(model_dim, hidden, activation));
         }
         Self {
             layers: v,

--- a/src/models/encoder.rs
+++ b/src/models/encoder.rs
@@ -10,10 +10,10 @@ pub struct EncoderLayerT {
 }
 
 impl EncoderLayerT {
-    pub fn new(dim: usize, hidden: usize) -> Self {
+    pub fn new(dim: usize, hidden: usize, activation: Activation) -> Self {
         Self {
             attn: Box::new(MultiHeadAttentionT::new(dim)),
-            ff: Box::new(FeedForwardT::new(dim, hidden, Activation::ReLU)),
+            ff: Box::new(FeedForwardT::new(dim, hidden, activation)),
             attn_out: Matrix::zeros(0, 0),
         }
     }
@@ -66,10 +66,16 @@ pub struct EncoderT {
 }
 
 impl EncoderT {
-    pub fn new(n: usize, vocab_size: usize, model_dim: usize, hidden: usize) -> Self {
+    pub fn new(
+        n: usize,
+        vocab_size: usize,
+        model_dim: usize,
+        hidden: usize,
+        activation: Activation,
+    ) -> Self {
         let mut v = Vec::new();
         for _ in 0..n {
-            v.push(EncoderLayerT::new(model_dim, hidden));
+            v.push(EncoderLayerT::new(model_dim, hidden, activation));
         }
         Self {
             layers: v,

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,7 +1,8 @@
-use crate::tensor::Tensor;
 use crate::data::load_pairs;
+use crate::layers::Activation;
 use crate::math::{self, Matrix};
 use crate::models::{DecoderT, EncoderT};
+use crate::tensor::Tensor;
 use crate::weights::{load_cnn, load_model};
 use rand::Rng;
 
@@ -24,8 +25,8 @@ pub fn run(model: Option<&str>) {
         "transformer" => {
             let vocab_size = 256;
             let model_dim = 64;
-            let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256);
-            let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256);
+            let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
+            let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
 
             load_model("model.json", &mut encoder, &mut decoder);
 


### PR DESCRIPTION
## Summary
- add tanh and leaky ReLU activation functions
- introduce parameterless softmax layer
- allow encoder and decoder to select activation function

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2b34eed8832fbf7ab8f898f3f995