### PR TITLE
Add mixture-of-experts flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 This here is a vanilla implementation of [NoProp](https://arxiv.org/html/2503.24322v2) according to *Qinyu Li*.
 It is part of a baremetal AI framework, not requering exhausting 3rd party libraries, compare *Cargo.toml*. 
 
-Call 
+Call
 ```
 ./run.sh
 ```
-to see the continously evolving command line parameters. 
+to see the continously evolving command line parameters.
 
 For example:
 ```
-./run.sh train-noprop cnn
-./run.sh predict
+./run.sh train-noprop cnn --moe --num-experts 4
+./run.sh predict --moe --num-experts 4
 ```
+The `--moe` flag enables mixture-of-experts layers and `--num-experts` sets
+how many experts to use.

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop} [model]" >&2
+  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop} [model] [--moe] [--num-experts N]" >&2
   exit 1
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -11,8 +11,28 @@ fn main() {
 
     match args[1].as_str() {
         "predict" => {
-            let model = args.get(2).map(|s| s.as_str());
-            predict::run(model);
+            let mut model: Option<String> = None;
+            let mut moe = false;
+            let mut num_experts = 1usize;
+            let mut i = 2;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--moe" => moe = true,
+                    "--num-experts" => {
+                        if i + 1 < args.len() {
+                            num_experts = args[i + 1].parse().unwrap_or(1);
+                            i += 1;
+                        }
+                    }
+                    other => {
+                        if !other.starts_with("--") && model.is_none() {
+                            model = Some(other.to_string());
+                        }
+                    }
+                }
+                i += 1;
+            }
+            predict::run(model.as_deref(), moe, num_experts);
         }
         "download" => data::download_mnist(),
         other => eprintln!("Unknown mode {}", other),

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -12,23 +12,47 @@ use vanillanoprop::train_cnn;
 use vanillanoprop::weights::save_model;
 
 fn main() {
-    let model = env::args()
-        .nth(1)
-        .unwrap_or_else(|| "transformer".to_string());
+    let mut args = env::args().skip(1);
+    let mut model = "transformer".to_string();
+    let mut moe = false;
+    let mut num_experts = 1usize;
+    let mut positional = Vec::new();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--moe" => moe = true,
+            "--num-experts" => {
+                if let Some(n) = args.next() {
+                    num_experts = n.parse().unwrap_or(1);
+                }
+            }
+            _ => positional.push(arg),
+        }
+    }
+    if let Some(m) = positional.get(0) {
+        model = m.clone();
+    }
     if model == "cnn" {
-        train_cnn::run("sgd");
+        train_cnn::run("sgd", moe, num_experts);
     } else {
-        run();
+        run(moe, num_experts);
     }
 }
 
-fn run() {
+fn run(moe: bool, num_experts: usize) {
     let batches = load_batches(4);
     let vocab_size = 256;
 
     // With embedding → model_dim separate
     let model_dim = 64;
-    let mut encoder = EncoderT::new(6, vocab_size, model_dim, 128, Activation::ReLU);
+    let mut encoder = EncoderT::new(
+        6,
+        vocab_size,
+        model_dim,
+        128,
+        Activation::ReLU,
+        moe,
+        num_experts,
+    );
     let lr = 0.001;
     let beta1 = 0.9;
     let beta2 = 0.999;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -14,7 +14,7 @@ fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
     m
 }
 
-pub fn run(model: Option<&str>) {
+pub fn run(model: Option<&str>, moe: bool, num_experts: usize) {
     // pick a random image from the MNIST training pairs
     let pairs = load_pairs();
     let mut rng = rand::thread_rng();
@@ -25,8 +25,24 @@ pub fn run(model: Option<&str>) {
         "transformer" => {
             let vocab_size = 256;
             let model_dim = 64;
-            let mut encoder = EncoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
-            let mut decoder = DecoderT::new(6, vocab_size, model_dim, 256, Activation::ReLU);
+            let mut encoder = EncoderT::new(
+                6,
+                vocab_size,
+                model_dim,
+                256,
+                Activation::ReLU,
+                moe,
+                num_experts,
+            );
+            let mut decoder = DecoderT::new(
+                6,
+                vocab_size,
+                model_dim,
+                256,
+                Activation::ReLU,
+                moe,
+                num_experts,
+            );
 
             load_model("model.json", &mut encoder, &mut decoder);
 

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -2,16 +2,17 @@ use indicatif::ProgressBar;
 
 use crate::data::load_batches;
 use crate::math;
+use crate::memory;
 use crate::metrics::f1_score;
 use crate::models::SimpleCNN;
 use crate::weights::save_cnn;
-use crate::memory;
 
 /// Train a [`SimpleCNN`] on the MNIST data using a basic SGD loop.
 ///
 /// `opt` is kept for parity with other training binaries but currently only
-/// SGD is implemented.
-pub fn run(opt: &str) {
+/// SGD is implemented.  `moe` and `num_experts` are accepted for API
+/// compatibility but currently unused.
+pub fn run(opt: &str, _moe: bool, _num_experts: usize) {
     let _ = opt; // optimizer placeholder
 
     let batches = load_batches(4);
@@ -107,6 +108,9 @@ pub fn run(opt: &str) {
 
     println!("Total matrix ops: {}", math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    println!("Max memory usage: {:.2} MB", peak as f64 / (1024.0 * 1024.0));
+    println!(
+        "Max memory usage: {:.2} MB",
+        peak as f64 / (1024.0 * 1024.0)
+    );
     save_cnn("cnn.json", &cnn);
 }


### PR DESCRIPTION
## Summary
- allow `--moe` and `--num-experts` flags in prediction and training binaries
- plumb mixture-of-experts settings into transformer model constructors
- document new CLI options and usage examples

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad43428cd0832fb4eaaf9e20a992a3