### PR TITLE
feat: add deterministic rng support

### DIFF
--- a/src/bin/compare.rs
+++ b/src/bin/compare.rs
@@ -1,5 +1,6 @@
 use indicatif::ProgressBar;
-use rand::random;
+use rand::Rng;
+use vanillanoprop::rng::rng_from_env;
 
 use vanillanoprop::data::{download_mnist, load_batches};
 use vanillanoprop::math;
@@ -102,6 +103,7 @@ fn train_backprop(epochs: usize) -> (f32, usize, usize, u64) {
 fn train_noprop(epochs: usize) -> (f32, usize, usize, u64) {
     let batches = load_batches(4);
     let mut cnn = SimpleCNN::new(10);
+    let mut rng = rng_from_env();
 
     let lr = 0.01f32;
 
@@ -126,7 +128,7 @@ fn train_noprop(epochs: usize) -> (f32, usize, usize, u64) {
                 let mut target = vec![0f32; logits.len()];
                 target[*tgt as usize] = 1.0;
                 for v in &mut target {
-                    *v += (random::<f32>() - 0.5) * 0.1;
+                    *v += (rng.gen::<f32>() - 0.5) * 0.1;
                 }
 
                 let mut delta = vec![0f32; logits.len()];

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -1,6 +1,8 @@
 use std::env;
 
 use indicatif::ProgressBar;
+use rand::Rng;
+use vanillanoprop::rng::rng_from_env;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::layers::Activation;
 use vanillanoprop::math::{self, Matrix};
@@ -23,6 +25,7 @@ fn main() {
 
 fn run(moe: bool, num_experts: usize) {
     let batches = load_batches(4);
+    let mut rng = rng_from_env();
     let vocab_size = 256;
 
     let model_dim = 64;
@@ -64,7 +67,7 @@ fn run(moe: bool, num_experts: usize) {
                 tgt_mat.set(0, tgt as usize, 1.0);
                 let mut noisy = encoder.forward(&tgt_mat);
                 for v in &mut noisy.data.data {
-                    *v += (rand::random::<f32>() - 0.5) * 0.1;
+                    *v += (rng.gen::<f32>() - 0.5) * 0.1;
                 }
 
                 // Mean squared error and local feedback alignment update

--- a/src/layers/dropout.rs
+++ b/src/layers/dropout.rs
@@ -1,4 +1,6 @@
 use crate::math::Matrix;
+use rand::Rng;
+use crate::rng::rng_from_env;
 
 /// Dropout layer that randomly zeros elements during training.
 ///
@@ -9,12 +11,13 @@ use crate::math::Matrix;
 /// backward pass.
 pub struct Dropout {
     mask: Vec<f32>,
+    rng: rand::rngs::StdRng,
 }
 
 impl Dropout {
     /// Create a new dropout layer.
     pub fn new() -> Self {
-        Self { mask: Vec::new() }
+        Self { mask: Vec::new(), rng: rng_from_env() }
     }
 
     /// Forward pass for dropout.
@@ -31,7 +34,7 @@ impl Dropout {
             self.mask = vec![0.0; x.data.len()];
             let scale = if p < 1.0 { 1.0 / (1.0 - p) } else { 0.0 };
             for i in 0..x.data.len() {
-                if rand::random::<f32>() < p {
+                if self.rng.gen::<f32>() < p {
                     self.mask[i] = 0.0;
                     out.data[i] = 0.0;
                 } else {

--- a/src/layers/linear.rs
+++ b/src/layers/linear.rs
@@ -1,6 +1,8 @@
 use crate::tensor::Tensor;
 use crate::math::Matrix;
 use super::layer::Layer;
+use rand::Rng;
+use crate::rng::rng_from_env;
 
 // Simple linear module with rudimentary autograd support.  During training
 // each `LinearT` stores the last input that was seen so that a backward pass
@@ -20,11 +22,12 @@ pub struct LinearT {
 
 impl LinearT {
     pub fn new(in_dim: usize, out_dim: usize) -> Self {
+        let mut rng = rng_from_env();
         let data = Matrix::from_vec(
             in_dim,
             out_dim,
             (0..in_dim * out_dim)
-                .map(|_| (rand::random::<f32>() - 0.5) * 0.02)
+                .map(|_| (rng.gen::<f32>() - 0.5) * 0.02)
                 .collect(),
         );
         let w = Tensor::from_matrix(data);
@@ -36,7 +39,7 @@ impl LinearT {
             out_dim,
             in_dim,
             (0..out_dim * in_dim)
-                .map(|_| (rand::random::<f32>() - 0.5) * 0.02)
+                .map(|_| (rng.gen::<f32>() - 0.5) * 0.02)
                 .collect(),
         );
         Self { w, grad, m, v, t: 0, last_x, fb }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod models;
 pub mod optim;
 pub mod positional;
 pub mod predict;
+pub mod rng;
 pub mod weights;
 pub mod train_cnn;
 pub mod memory;

--- a/src/models/cnn.rs
+++ b/src/models/cnn.rs
@@ -1,5 +1,6 @@
 use crate::math::{self, Matrix};
 use rand::Rng;
+use crate::rng::rng_from_env;
 
 /// A very small convolutional network used for demonstration purposes.
 ///
@@ -18,7 +19,7 @@ impl SimpleCNN {
     pub fn new(num_classes: usize) -> Self {
         // 3x3 mean kernel
         let kernel = [[1.0 / 9.0; 3]; 3];
-        let mut rng = rand::thread_rng();
+        let mut rng = rng_from_env();
         let mut w = Vec::with_capacity(28 * 28 * num_classes);
         for _ in 0..(28 * 28 * num_classes) {
             w.push(rng.gen_range(-0.01..0.01));

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -5,6 +5,7 @@ use crate::models::{DecoderT, EncoderT};
 use crate::tensor::Tensor;
 use crate::weights::{load_cnn, load_model};
 use rand::Rng;
+use crate::rng::rng_from_env;
 
 fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
     let mut m = Matrix::zeros(seq.len(), vocab_size);
@@ -17,7 +18,7 @@ fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
 pub fn run(model: Option<&str>, moe: bool, num_experts: usize) {
     // pick a random image from the MNIST training pairs
     let pairs = load_pairs();
-    let mut rng = rand::thread_rng();
+    let mut rng = rng_from_env();
     let idx = rng.gen_range(0..pairs.len());
     let (src, tgt) = &pairs[idx];
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,17 @@
+use rand::{rngs::StdRng, SeedableRng};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Create a [`StdRng`] seeded from the `SEED` environment variable.
+///
+/// Each call uses a unique seed derived from the base seed and an
+/// incrementing counter to ensure deterministic yet distinct streams.
+pub fn rng_from_env() -> StdRng {
+    let base = std::env::var("SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let idx = COUNTER.fetch_add(1, Ordering::SeqCst);
+    StdRng::seed_from_u64(base + idx)
+}


### PR DESCRIPTION
## Summary
- introduce shared `StdRng` seeded from `SEED` env var
- replace `rand::random` and `thread_rng` usages with deterministic RNG
- allow reproducible noise and sampling in training and prediction

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad5757b538832facd5b42227f00202