### PR TITLE
Validate Conv2d input dimensions

### DIFF
--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -48,8 +48,17 @@ impl Conv2d {
 
     fn compute_shapes(&self, x: &Matrix) -> (usize, usize, usize, usize, usize) {
         let batch = x.rows;
+        if x.cols % self.in_channels != 0 {
+            panic!(
+                "Input feature count {} is not divisible by in_channels {}",
+                x.cols, self.in_channels
+            );
+        }
         let in_hw = x.cols / self.in_channels;
         let in_h = (in_hw as f32).sqrt() as usize;
+        if in_h * in_h != in_hw {
+            panic!("Input spatial size {} is not a perfect square", in_hw);
+        }
         let in_w = in_h; // assume square inputs
         let out_h = (in_h + 2 * self.padding - self.kernel_size) / self.stride + 1;
         let out_w = (in_w + 2 * self.padding - self.kernel_size) / self.stride + 1;

--- a/tests/conv.rs
+++ b/tests/conv.rs
@@ -1,0 +1,25 @@
+use vanillanoprop::layers::Conv2d;
+use vanillanoprop::math::Matrix;
+
+#[test]
+fn conv_forward_accepts_valid_square() {
+    let mut conv = Conv2d::new(1, 1, 1, 1, 0);
+    let x = Matrix::from_vec(1, 4, vec![1.0, 2.0, 3.0, 4.0]);
+    let _ = conv.forward_local(&x);
+}
+
+#[test]
+#[should_panic(expected = "not divisible by in_channels")]
+fn conv_forward_panics_on_channel_mismatch() {
+    let mut conv = Conv2d::new(3, 1, 1, 1, 0);
+    let x = Matrix::from_vec(1, 7, vec![0.0; 7]);
+    let _ = conv.forward_local(&x);
+}
+
+#[test]
+#[should_panic(expected = "not a perfect square")]
+fn conv_forward_panics_on_non_square_input() {
+    let mut conv = Conv2d::new(1, 1, 1, 1, 0);
+    let x = Matrix::from_vec(1, 3, vec![0.0; 3]);
+    let _ = conv.forward_local(&x);
+}


### PR DESCRIPTION
## Summary
- ensure Conv2d input feature count is divisible by channels and forms a square
- add tests covering valid inputs and panic scenarios

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad765c4660832fa8ce7bfa67902e8f