### PR TITLE
Avoid unnecessary clones in encoder and decoder

### DIFF
--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -65,7 +65,7 @@ fn run(moe: bool, num_experts: usize) {
                 // encode target without affecting gradients and add noise
                 let mut tgt_mat = Matrix::zeros(1, vocab_size);
                 tgt_mat.set(0, tgt as usize, 1.0);
-                let mut noisy = encoder.forward(&tgt_mat);
+                let mut noisy = encoder.forward(tgt_mat);
                 for v in &mut noisy.data.data {
                     *v += (rng.gen::<f32>() - 0.5) * 0.1;
                 }

--- a/src/models/decoder.rs
+++ b/src/models/decoder.rs
@@ -43,7 +43,7 @@ impl DecoderLayerT {
         let ctx = if h1.data.rows == enc_out.data.rows && h1.data.cols == enc_out.data.cols {
             Tensor::add(&h1, enc_out)
         } else {
-            h1.clone()
+            h1
         };
         let h2 = self.enc_dec_attn.forward(&ctx);
         self.ff.forward(&h2)

--- a/src/models/encoder.rs
+++ b/src/models/encoder.rs
@@ -109,9 +109,9 @@ impl EncoderT {
         }
     }
 
-    pub fn forward(&self, x: &Matrix) -> Tensor {
+    pub fn forward(&self, x: Matrix) -> Tensor {
         // existing inference path
-        let mut h = Tensor::from_matrix(x.clone());
+        let mut h = Tensor::from_matrix(x);
         h = self.embedding.forward(&h);
         let pos = positional_encoding(h.data.rows, h.data.cols);
         let p = Tensor::from_matrix(pos);

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -51,7 +51,7 @@ pub fn run(model: Option<&str>, moe: bool, num_experts: usize) {
 
             math::reset_matrix_ops();
             let enc_x = to_matrix(src, vocab_size);
-            let enc_out = encoder.forward(&enc_x);
+            let enc_out = encoder.forward(enc_x);
 
             // Average encoder activations across the sequence
             let mut avg = Matrix::zeros(1, enc_out.data.cols);


### PR DESCRIPTION
## Summary
- eliminate redundant matrix cloning in `EncoderT::forward` by taking ownership of input
- drop decoder layer clone by reusing attention output when shapes mismatch
- update call sites to pass matrices by value

## Testing
- `cargo test`
- `cargo run --bin mem` (before/after)

------
https://chatgpt.com/codex/tasks/task_e_68ad79f5cd84832f8528ba69d2c00d4c