### PR TITLE
Implement blocked CPU matmul and add benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "libc",
  "mnist",
  "rand",
+ "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rand = "0.8"
 indicatif = "0.17"
 mnist = { version = "0.6", features = ["download"] }
 libc = "0.2"
+rayon = "1.8"
 
 [lib]
 name = "vanillanoprop"
@@ -41,4 +42,8 @@ criterion = "0.5"
 
 [[bench]]
 name = "mask_topk"
+harness = false
+
+[[bench]]
+name = "matmul"
 harness = false

--- a/benches/matmul.rs
+++ b/benches/matmul.rs
@@ -1,0 +1,45 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::Rng;
+use vanillanoprop::math::Matrix;
+
+fn matmul_naive(a: &Matrix, b: &Matrix) -> Matrix {
+    assert_eq!(a.cols, b.rows);
+    let mut out = vec![0.0; a.rows * b.cols];
+    for i in 0..a.rows {
+        let a_row = &a.data[i * a.cols..(i + 1) * a.cols];
+        for k in 0..a.cols {
+            let a_val = a_row[k];
+            let b_row = &b.data[k * b.cols..(k + 1) * b.cols];
+            for j in 0..b.cols {
+                out[i * b.cols + j] += a_val * b_row[j];
+            }
+        }
+    }
+    Matrix::from_vec(a.rows, b.cols, out)
+}
+
+fn bench_matmul(c: &mut Criterion) {
+    let size = 256;
+    let mut rng = rand::thread_rng();
+    let a_data: Vec<f32> = (0..size * size).map(|_| rng.gen()).collect();
+    let b_data: Vec<f32> = (0..size * size).map(|_| rng.gen()).collect();
+    let a = Matrix::from_vec(size, size, a_data);
+    let b = Matrix::from_vec(size, size, b_data);
+
+    c.bench_function("matmul_naive", |bencher| {
+        bencher.iter(|| {
+            let res = matmul_naive(black_box(&a), black_box(&b));
+            black_box(res);
+        });
+    });
+
+    c.bench_function("matmul_blocked", |bencher| {
+        bencher.iter(|| {
+            let res = Matrix::matmul(black_box(&a), black_box(&b));
+            black_box(res);
+        });
+    });
+}
+
+criterion_group!(benches, bench_matmul);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- optimize `matmul_cpu` with 32×32 tiling and optional Rayon-based parallelism for large matrices
- add `rayon` dependency and criterion benchmark comparing naive and blocked implementations

## Testing
- `cargo test`
- `cargo bench`


------
https://chatgpt.com/codex/tasks/task_e_68ada931c8bc832f80b6c3734701112a