### PR TITLE
Add checkpointing and resume support

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -3,7 +3,7 @@ use vanillanoprop::optim::lr_scheduler::LrScheduleConfig;
 
 /// Parses common CLI arguments across training binaries.
 ///
-/// Returns a tuple `(model, optimizer, moe, num_experts, lr_schedule, positional_args)`.
+/// Returns a tuple `(model, optimizer, moe, num_experts, lr_schedule, resume, save_every, checkpoint_dir, positional_args)`.
 /// - `model` defaults to "transformer" if not specified.
 /// - `optimizer` defaults to "sgd" if not specified.
 /// - `moe` is true if `--moe` flag is present.
@@ -11,8 +11,24 @@ use vanillanoprop::optim::lr_scheduler::LrScheduleConfig;
 /// - `lr_schedule` selects the learning rate schedule: "step", "cosine" or
 ///   omitted for a constant rate. Additional hyperparameters can be provided via
 ///   `--lr-step-size`, `--lr-gamma` and `--lr-max-steps`.
+/// - `resume` specifies a checkpoint file to load via `--resume <file>`.
+/// - `save_every` saves checkpoints every N epochs with `--save-every N`.
+/// - `checkpoint_dir` overrides the directory in which checkpoints are stored
+///   using `--checkpoint-dir <dir>`.
 /// - `positional_args` contains remaining positional arguments in order.
-pub fn parse_cli<I>(mut args: I) -> (String, String, bool, usize, LrScheduleConfig, Vec<String>)
+pub fn parse_cli<I>(
+    mut args: I,
+) -> (
+    String,
+    String,
+    bool,
+    usize,
+    LrScheduleConfig,
+    Option<String>,
+    Option<usize>,
+    Option<String>,
+    Vec<String>,
+)
 where
     I: Iterator<Item = String>,
 {
@@ -24,6 +40,9 @@ where
     let mut step_size = 10usize;
     let mut gamma = 0.5f32;
     let mut max_steps = 1000usize;
+    let mut resume = None;
+    let mut save_every = None;
+    let mut checkpoint_dir = None;
     let mut positional = Vec::new();
 
     while let Some(arg) = args.next() {
@@ -54,6 +73,21 @@ where
                     max_steps = v.parse().unwrap_or(max_steps);
                 }
             }
+            "--resume" => {
+                if let Some(p) = args.next() {
+                    resume = Some(p);
+                }
+            }
+            "--save-every" => {
+                if let Some(v) = args.next() {
+                    save_every = v.parse().ok();
+                }
+            }
+            "--checkpoint-dir" => {
+                if let Some(v) = args.next() {
+                    checkpoint_dir = Some(v);
+                }
+            }
             _ => positional.push(arg),
         }
     }
@@ -71,12 +105,33 @@ where
         _ => LrScheduleConfig::Constant,
     };
 
-    (model, opt, moe, num_experts, lr_schedule, positional)
+    (
+        model,
+        opt,
+        moe,
+        num_experts,
+        lr_schedule,
+        resume,
+        save_every,
+        checkpoint_dir,
+        positional,
+    )
 }
 
 /// Convenience wrapper that parses arguments from the current process
 /// (skipping the binary name).
-pub fn parse_env() -> (String, String, bool, usize, LrScheduleConfig, Vec<String>) {
+pub fn parse_env(
+) -> (
+    String,
+    String,
+    bool,
+    usize,
+    LrScheduleConfig,
+    Option<String>,
+    Option<usize>,
+    Option<String>,
+    Vec<String>,
+) {
     let args = env::args().skip(1);
     parse_cli(args)
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,8 +13,17 @@ fn main() {
 
     match args[1].as_str() {
         "predict" => {
-            let (model, _opt, moe, num_experts, _lr_cfg, positional) =
-                common::parse_cli(args[2..].iter().cloned());
+            let (
+                model,
+                _opt,
+                moe,
+                num_experts,
+                _lr_cfg,
+                _resume,
+                _save_every,
+                _ckpt_dir,
+                positional,
+            ) = common::parse_cli(args[2..].iter().cloned());
             let model_opt = if positional.is_empty() {
                 None
             } else {

--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -14,9 +14,19 @@ use vanillanoprop::weights::save_model;
 mod common;
 
 fn main() {
-    let (model, opt, moe, num_experts, lr_cfg, _) = common::parse_cli(env::args().skip(1));
+    let (
+        model,
+        opt,
+        moe,
+        num_experts,
+        lr_cfg,
+        _resume,
+        _save_every,
+        _ckpt_dir,
+        _,
+    ) = common::parse_cli(env::args().skip(1));
     if model == "cnn" {
-        train_cnn::run(&opt, moe, num_experts, lr_cfg);
+        train_cnn::run(&opt, moe, num_experts, lr_cfg, None, None, None);
     } else {
         run(&opt, moe, num_experts);
     }

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -14,9 +14,19 @@ use vanillanoprop::weights::save_model;
 mod common;
 
 fn main() {
-    let (model, _opt, moe, num_experts, lr_cfg, _) = common::parse_cli(env::args().skip(1));
+    let (
+        model,
+        _opt,
+        moe,
+        num_experts,
+        lr_cfg,
+        _resume,
+        _save_every,
+        _ckpt_dir,
+        _,
+    ) = common::parse_cli(env::args().skip(1));
     if model == "cnn" {
-        train_cnn::run("sgd", moe, num_experts, lr_cfg);
+        train_cnn::run("sgd", moe, num_experts, lr_cfg, None, None, None);
     } else {
         run(moe, num_experts);
     }

--- a/src/optim/hrm.rs
+++ b/src/optim/hrm.rs
@@ -1,10 +1,12 @@
 use crate::math::{self, Matrix};
+use serde::{Deserialize, Serialize};
 
 /// Optimizer implementing the https://arxiv.org/abs/2506.21734 "Hierarchical Reasoning Model" algorithm.
 ///
 /// The algorithm uses a simple decaying learning rate to update a linear layer
 /// given the feature vector and gradient on the output logits.  This is merely
 /// a lightweight placeholder capturing the core idea.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Hrm {
     pub lr: f32,
     pub decay: f32,


### PR DESCRIPTION
## Summary
- add generic checkpoint save/load utilities
- extend CLI with --resume, --save-every and --checkpoint-dir
- persist optimizer state and metrics to resume training for CNN and transformer loops

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae00ec8d28832f99535400ec86dd79