### PR TITLE
Add configuration-based training parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,10 +298,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indicatif"
@@ -663,6 +685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +731,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +795,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -928,6 +1001,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ indicatif = "0.17"
 mnist = { version = "0.6", features = ["download"] }
 libc = "0.2"
 rayon = "1.8"
+toml = "0.8"
 
 [lib]
 name = "vanillanoprop"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,26 @@ For example:
 ```
 The `--moe` flag enables mixture-of-experts layers and `--num-experts` sets
 how many experts to use.
+
+## Configuration
+
+Training parameters such as the number of epochs and batch size can be set via
+a configuration file in TOML or JSON format. CLI flags override values from the
+file. Example `config.toml`:
+
+```
+epochs = 10
+batch_size = 8
+```
+
+Run a training binary with a configuration file:
+
+```
+./run.sh train-noprop --config config.toml
+```
+
+Or override specific settings from the command line:
+
+```
+./run.sh train-noprop --config config.toml --epochs 20 --batch-size 16
+```

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -22,6 +22,7 @@ fn main() {
                 _resume,
                 _save_every,
                 _ckpt_dir,
+                _config,
                 positional,
             ) = common::parse_cli(args[2..].iter().cloned());
             let model_opt = if positional.is_empty() {

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -9,6 +9,7 @@ use vanillanoprop::metrics::f1_score;
 use vanillanoprop::models::EncoderT;
 use vanillanoprop::optim::Adam;
 use vanillanoprop::train_cnn;
+use vanillanoprop::config::Config;
 use vanillanoprop::weights::save_model;
 
 mod common;
@@ -23,17 +24,18 @@ fn main() {
         _resume,
         _save_every,
         _ckpt_dir,
+        config,
         _,
     ) = common::parse_cli(env::args().skip(1));
     if model == "cnn" {
-        train_cnn::run("sgd", moe, num_experts, lr_cfg, None, None, None);
+        train_cnn::run("sgd", moe, num_experts, lr_cfg, None, None, None, &config);
     } else {
-        run(moe, num_experts);
+        run(moe, num_experts, &config);
     }
 }
 
-fn run(moe: bool, num_experts: usize) {
-    let batches = load_batches(4);
+fn run(moe: bool, num_experts: usize, config: &Config) {
+    let batches = load_batches(config.batch_size);
     let vocab_size = 256;
 
     // With embedding → model_dim separate
@@ -55,7 +57,7 @@ fn run(moe: bool, num_experts: usize) {
     let mut optim = Adam::new(lr, beta1, beta2, eps, weight_decay);
 
     math::reset_matrix_ops();
-    let epochs = 5;
+    let epochs = config.epochs;
     let pb = ProgressBar::new(epochs as u64);
     let mut best_f1 = f32::NEG_INFINITY;
     for epoch in 0..epochs {

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -16,6 +16,7 @@ use vanillanoprop::optim::lr_scheduler::{
 };
 use vanillanoprop::rng::rng_from_env;
 use vanillanoprop::train_cnn;
+use vanillanoprop::config::Config;
 use vanillanoprop::weights::{
     save_model, save_checkpoint, load_checkpoint, ModelJson, tensor_to_vec2,
 };
@@ -32,12 +33,13 @@ fn main() {
         resume,
         save_every,
         checkpoint_dir,
+        config,
         _,
     ) = common::parse_cli(env::args().skip(1));
     if model == "cnn" {
-        train_cnn::run(&opt, moe, num_experts, lr_cfg, resume, save_every, checkpoint_dir);
+        train_cnn::run(&opt, moe, num_experts, lr_cfg, resume, save_every, checkpoint_dir, &config);
     } else {
-        run(moe, num_experts, lr_cfg, resume, save_every, checkpoint_dir);
+        run(moe, num_experts, lr_cfg, resume, save_every, checkpoint_dir, &config);
     }
 }
 
@@ -56,8 +58,9 @@ fn run(
     resume: Option<String>,
     save_every: Option<usize>,
     checkpoint_dir: Option<String>,
+    config: &Config,
 ) {
-    let batches = load_batches(4);
+    let batches = load_batches(config.batch_size);
     let mut rng = rng_from_env();
     let vocab_size = 256;
 
@@ -114,10 +117,9 @@ fn run(
     });
 
     math::reset_matrix_ops();
-    let epochs = 5;
-    let pb = ProgressBar::new(epochs as u64);
+    let pb = ProgressBar::new(config.epochs as u64);
     pb.set_position(start_epoch as u64);
-    for epoch in start_epoch..epochs {
+    for epoch in start_epoch..config.epochs {
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+use std::fs;
+
+/// Training configuration loaded from a TOML or JSON file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    /// Number of training epochs.
+    pub epochs: usize,
+    /// Batch size used when loading data.
+    pub batch_size: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { epochs: 5, batch_size: 4 }
+    }
+}
+
+impl Config {
+    /// Load configuration from the given path.  Supports TOML or JSON based on
+    /// the file extension. Returns `None` if parsing fails.
+    pub fn from_path(path: &str) -> Option<Self> {
+        let Ok(content) = fs::read_to_string(path) else {
+            return None;
+        };
+        if path.ends_with(".json") {
+            serde_json::from_str(&content).ok()
+        } else {
+            toml::from_str(&content).ok()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod rng;
 pub mod weights;
 pub mod train_cnn;
 pub mod memory;
+pub mod config;

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -1,6 +1,7 @@
 use indicatif::ProgressBar;
 
 use crate::data::load_batches;
+use crate::config::Config;
 use crate::math::{self, Matrix};
 use crate::memory;
 use crate::metrics::f1_score;
@@ -36,8 +37,9 @@ pub fn run(
     resume: Option<String>,
     save_every: Option<usize>,
     checkpoint_dir: Option<String>,
+    config: &Config,
 ) {
-    let batches = load_batches(4);
+    let batches = load_batches(config.batch_size);
     let mut cnn = SimpleCNN::new(10);
 
     let base_lr = 0.01f32;
@@ -49,7 +51,7 @@ pub fn run(
         LrScheduleConfig::Cosine { max_steps } => Box::new(CosineLr::new(base_lr, max_steps)),
         LrScheduleConfig::Constant => Box::new(ConstantLr::new(base_lr)),
     };
-    let epochs = 5;
+    let epochs = config.epochs;
     let mut step = 0usize;
     let mut start_epoch = 0usize;
     let mut best_f1 = f32::NEG_INFINITY;


### PR DESCRIPTION
## Summary
- add `Config` struct loading epochs and batch size from TOML/JSON files
- extend training CLI with `--epochs`, `--batch-size` and `--config`
- refactor training binaries to use `Config` values
- document configuration usage

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae02fc61dc832f9b0293cfb9a40fee