### PR TITLE
Add basic VAE model with training and sampling CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -592,6 +599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -814,6 +831,7 @@ dependencies = [
  "libc",
  "mnist",
  "rand",
+ "rand_distr",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8"
+rand_distr = "0.4"
 indicatif = "0.17"
 mnist = { version = "0.6", features = ["download"] }
 libc = "0.2"
@@ -42,6 +43,14 @@ path = "src/bin/compare.rs"
 [[bin]]
 name = "plot_metrics"
 path = "scripts/plot_metrics.rs"
+
+[[bin]]
+name = "train_vae"
+path = "src/bin/train_vae.rs"
+
+[[bin]]
+name = "sample_vae"
+path = "src/bin/sample_vae.rs"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/bin/sample_vae.rs
+++ b/src/bin/sample_vae.rs
@@ -1,0 +1,21 @@
+use std::env;
+use vanillanoprop::math::Matrix;
+use vanillanoprop::rng::rng_from_env;
+use vanillanoprop::weights::load_vae;
+use rand_distr::{Distribution, StandardNormal};
+
+fn main() {
+    let path = env::args().nth(1).unwrap_or_else(|| "vae.json".to_string());
+    let input_dim = 28 * 28;
+    let hidden_dim = 400;
+    let latent_dim = 20;
+    let mut vae = load_vae(&path, input_dim, hidden_dim, latent_dim).expect("load vae");
+    let mut rng = rng_from_env();
+    let mut z = Matrix::zeros(1, latent_dim);
+    for i in 0..latent_dim {
+        let e: f32 = StandardNormal.sample(&mut rng);
+        z.set(0, i, e);
+    }
+    let sample = vae.decode(&z);
+    println!("sample first values: {:?}", &sample.data[..10.min(sample.data.len())]);
+}

--- a/src/bin/train_vae.rs
+++ b/src/bin/train_vae.rs
@@ -1,0 +1,35 @@
+use vanillanoprop::data::load_pairs;
+use vanillanoprop::math::{kl_divergence, mse_loss, Matrix};
+use vanillanoprop::models::VAE;
+use vanillanoprop::optim::Adam;
+use vanillanoprop::weights::save_vae;
+
+fn main() {
+    let pairs = load_pairs();
+    let input_dim = 28 * 28;
+    let hidden_dim = 400;
+    let latent_dim = 20;
+    let mut vae = VAE::new(input_dim, hidden_dim, latent_dim);
+    let mut adam = Adam::new(0.001, 0.9, 0.999, 1e-8, 0.0);
+
+    for epoch in 0..3 {
+        let mut total = 0.0f32;
+        for (pixels, _) in &pairs {
+            let x_vec: Vec<f32> = pixels.iter().map(|&p| p as f32 / 255.0).collect();
+            let x = Matrix::from_vec(1, input_dim, x_vec);
+            let (recon, mu, logvar) = vae.forward_train(&x);
+            let (recon_loss, grad_recon) = mse_loss(&recon, &x);
+            let (kl_loss, grad_mu_kl, grad_logvar_kl) = kl_divergence(&mu, &logvar);
+            vae.zero_grad();
+            vae.backward(&grad_recon, &grad_mu_kl, &grad_logvar_kl);
+            let mut params = vae.parameters();
+            adam.step(&mut params);
+            total += recon_loss + kl_loss;
+        }
+        println!("epoch {epoch} loss {:.4}", total / pairs.len() as f32);
+    }
+
+    if let Err(e) = save_vae("vae.json", &vae) {
+        eprintln!("failed to save model: {e}");
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,9 +2,11 @@ pub mod encoder;
 pub mod decoder;
 pub mod cnn;
 pub mod large_concept;
+pub mod vae;
 
 pub use encoder::{EncoderLayerT, EncoderT};
 pub use decoder::{DecoderLayerT, DecoderT};
 pub use cnn::SimpleCNN;
 pub use large_concept::LargeConceptModel;
+pub use vae::VAE;
 

--- a/src/models/vae.rs
+++ b/src/models/vae.rs
@@ -1,0 +1,133 @@
+use crate::layers::linear::LinearT;
+use crate::layers::{relu, sigmoid};
+use crate::math::Matrix;
+use crate::rng::rng_from_env;
+use rand_distr::{Distribution, StandardNormal};
+
+pub struct VAE {
+    pub enc_fc1: LinearT,
+    pub enc_mu: LinearT,
+    pub enc_logvar: LinearT,
+    pub dec_fc1: LinearT,
+    pub dec_fc2: LinearT,
+    // caches for backward
+    enc_mask: Vec<f32>,
+    dec_mask: Vec<f32>,
+    pub mu: Matrix,
+    pub logvar: Matrix,
+    std: Matrix,
+    eps: Matrix,
+    z: Matrix,
+    recon: Matrix,
+}
+
+impl VAE {
+    pub fn new(input_dim: usize, hidden_dim: usize, latent_dim: usize) -> Self {
+        Self {
+            enc_fc1: LinearT::new(input_dim, hidden_dim),
+            enc_mu: LinearT::new(hidden_dim, latent_dim),
+            enc_logvar: LinearT::new(hidden_dim, latent_dim),
+            dec_fc1: LinearT::new(latent_dim, hidden_dim),
+            dec_fc2: LinearT::new(hidden_dim, input_dim),
+            enc_mask: Vec::new(),
+            dec_mask: Vec::new(),
+            mu: Matrix::zeros(0, 0),
+            logvar: Matrix::zeros(0, 0),
+            std: Matrix::zeros(0, 0),
+            eps: Matrix::zeros(0, 0),
+            z: Matrix::zeros(0, 0),
+            recon: Matrix::zeros(0, 0),
+        }
+    }
+
+    pub fn forward_train(&mut self, x: &Matrix) -> (Matrix, Matrix, Matrix) {
+        // encoder
+        let mut h1 = self.enc_fc1.forward_train(x);
+        self.enc_mask = relu::forward_matrix(&mut h1);
+        self.mu = self.enc_mu.forward_train(&h1);
+        self.logvar = self.enc_logvar.forward_train(&h1);
+
+        // reparameterization
+        let mut rng = rng_from_env();
+        let mut z = Matrix::zeros(self.mu.rows, self.mu.cols);
+        let mut std = Matrix::zeros(self.mu.rows, self.mu.cols);
+        let mut eps = Matrix::zeros(self.mu.rows, self.mu.cols);
+        for i in 0..self.mu.data.len() {
+            let lv = self.logvar.data[i];
+            let s = (0.5 * lv).exp();
+            let e: f32 = StandardNormal.sample(&mut rng);
+            std.data[i] = s;
+            eps.data[i] = e;
+            z.data[i] = self.mu.data[i] + e * s;
+        }
+        self.std = std;
+        self.eps = eps;
+        self.z = z.clone();
+
+        // decoder
+        let mut h2 = self.dec_fc1.forward_train(&z);
+        self.dec_mask = relu::forward_matrix(&mut h2);
+        let mut recon = self.dec_fc2.forward_train(&h2);
+        sigmoid::forward_matrix(&mut recon);
+        self.recon = recon.clone();
+        (recon, self.mu.clone(), self.logvar.clone())
+    }
+
+    pub fn decode(&mut self, z: &Matrix) -> Matrix {
+        let mut h1 = self.dec_fc1.forward_local(z);
+        let _ = relu::forward_matrix(&mut h1);
+        let mut out = self.dec_fc2.forward_local(&h1);
+        sigmoid::forward_matrix(&mut out);
+        out
+    }
+
+    pub fn backward(
+        &mut self,
+        grad_recon: &Matrix,
+        grad_mu_kl: &Matrix,
+        grad_logvar_kl: &Matrix,
+    ) {
+        // decoder
+        let mut g = grad_recon.clone();
+        sigmoid::backward(&mut g, &self.recon);
+        let grad_h2 = self.dec_fc2.backward(&g);
+        let mut grad_h2_act = grad_h2.clone();
+        for (i, v) in grad_h2_act.data.iter_mut().enumerate() {
+            *v *= self.dec_mask[i];
+        }
+        let grad_z = self.dec_fc1.backward(&grad_h2_act);
+
+        // gradients for mu and logvar
+        let grad_mu = grad_z.add(grad_mu_kl);
+        let mut grad_logvar = Matrix::zeros(self.logvar.rows, self.logvar.cols);
+        for i in 0..grad_logvar.data.len() {
+            let g = grad_z.data[i] * self.eps.data[i] * 0.5 * self.std.data[i];
+            grad_logvar.data[i] = g + grad_logvar_kl.data[i];
+        }
+        let grad_h1_mu = self.enc_mu.backward(&grad_mu);
+        let grad_h1_logvar = self.enc_logvar.backward(&grad_logvar);
+        let mut grad_h1 = grad_h1_mu.add(&grad_h1_logvar);
+        for (i, v) in grad_h1.data.iter_mut().enumerate() {
+            *v *= self.enc_mask[i];
+        }
+        self.enc_fc1.backward(&grad_h1);
+    }
+
+    pub fn zero_grad(&mut self) {
+        self.enc_fc1.zero_grad();
+        self.enc_mu.zero_grad();
+        self.enc_logvar.zero_grad();
+        self.dec_fc1.zero_grad();
+        self.dec_fc2.zero_grad();
+    }
+
+    pub fn parameters(&mut self) -> Vec<&mut LinearT> {
+        vec![
+            &mut self.enc_fc1,
+            &mut self.enc_mu,
+            &mut self.enc_logvar,
+            &mut self.dec_fc1,
+            &mut self.dec_fc2,
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- implement variational autoencoder with encoder/decoder and reparameterization trick
- add MSE and KL-divergence losses plus save/load helpers for VAE weights
- introduce `train_vae` and `sample_vae` command line binaries

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d3535fc832f8e9422257e187e5d