### PR TITLE
Add ResNet model and training script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop|train-lcm} [model] [opt] [--moe] [--num-experts N]" >&2
+  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop|train-lcm|train-resnet} [model] [opt] [--moe] [--num-experts N]" >&2
   exit 1
 }
 
@@ -33,6 +33,10 @@ case "$1" in
   train-lcm)
     shift
     cargo run --bin main -- train-lcm "$@"
+    ;;
+  train-resnet)
+    shift
+    cargo run --bin train_resnet -- "$@"
     ;;
   *)
     usage

--- a/src/bin/train_resnet.rs
+++ b/src/bin/train_resnet.rs
@@ -1,0 +1,144 @@
+use std::env;
+
+use indicatif::ProgressBar;
+use vanillanoprop::config::Config;
+use vanillanoprop::data::load_batches;
+use vanillanoprop::logging::{Logger, MetricRecord};
+use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::memory;
+use vanillanoprop::metrics::f1_score;
+use vanillanoprop::models::ResNet;
+use vanillanoprop::optim::lr_scheduler::{
+    ConstantLr, CosineLr, LearningRateSchedule, LrScheduleConfig, StepLr,
+};
+use vanillanoprop::optim::Hrm;
+
+mod common;
+
+fn main() {
+    let (
+        _model,
+        opt,
+        _moe,
+        _num_experts,
+        lr_cfg,
+        _resume,
+        _save_every,
+        _ckpt_dir,
+        log_dir,
+        experiment,
+        config,
+        _,
+    ) = common::parse_cli(env::args().skip(1));
+    run(&opt, lr_cfg, log_dir, experiment, &config);
+}
+
+fn run(
+    opt: &str,
+    lr_cfg: LrScheduleConfig,
+    log_dir: Option<String>,
+    experiment_name: Option<String>,
+    config: &Config,
+) {
+    let batches = load_batches(config.batch_size);
+    // 64 hidden units and 2 residual blocks as a default configuration.
+    let mut model = ResNet::new(10, 64, 2);
+
+    let base_lr = 0.01f32;
+    let mut hrm = Hrm::new(base_lr, 0.0);
+    let scheduler: Box<dyn LearningRateSchedule> = match lr_cfg {
+        LrScheduleConfig::Step { step_size, gamma } => {
+            Box::new(StepLr::new(base_lr, step_size, gamma))
+        }
+        LrScheduleConfig::Cosine { max_steps } => Box::new(CosineLr::new(base_lr, max_steps)),
+        LrScheduleConfig::Constant => Box::new(ConstantLr::new(base_lr)),
+    };
+
+    let epochs = config.epochs;
+    let mut step = 0usize;
+    let mut logger = Logger::new(log_dir, experiment_name).ok();
+    let pb = ProgressBar::new(epochs as u64);
+    let mut last_lr = base_lr;
+
+    math::reset_matrix_ops();
+
+    for epoch in 0..epochs {
+        let mut last_loss = 0.0f32;
+        let mut f1_sum = 0.0f32;
+        let mut sample_cnt = 0.0f32;
+        for batch in &batches {
+            let mut batch_loss = 0.0f32;
+            let mut batch_f1 = 0.0f32;
+            for (img, tgt) in batch {
+                let (feat, logits) = model.forward(img);
+                let logits_m = Matrix::from_vec(1, logits.len(), logits);
+                let (loss, grad_m, preds) =
+                    math::softmax_cross_entropy(&logits_m, &[*tgt as usize], 0);
+                batch_loss += loss;
+                let grad_logits = grad_m.data;
+
+                let (fc, bias) = model.parameters_mut();
+                let lr = scheduler.next_lr(step);
+                last_lr = lr;
+                if opt == "hrm" {
+                    hrm.lr = lr;
+                    hrm.update(fc, bias, &grad_logits, &feat);
+                } else {
+                    let rows = fc.rows;
+                    let cols = fc.cols;
+                    let mut grad_matrix = vec![0.0f32; rows * cols];
+                    for (c, &g) in grad_logits.iter().enumerate() {
+                        for (r, &f) in feat.iter().enumerate() {
+                            grad_matrix[r * cols + c] = f * g;
+                        }
+                    }
+                    for (w, &g) in fc.data.iter_mut().zip(grad_matrix.iter()) {
+                        *w -= lr * g;
+                    }
+                    for (b, &g) in bias.iter_mut().zip(grad_logits.iter()) {
+                        *b -= lr * g;
+                    }
+                }
+
+                let f1 = f1_score(&preds, &[*tgt as usize]);
+                batch_f1 += f1;
+                step += 1;
+            }
+            let bsz = batch.len() as f32;
+            batch_loss /= bsz;
+            let batch_f1_avg = batch_f1 / bsz;
+            last_loss = batch_loss;
+            f1_sum += batch_f1;
+            sample_cnt += bsz;
+            println!("loss {batch_loss:.4} f1 {batch_f1_avg:.4}");
+            if let Some(l) = &mut logger {
+                l.log(&MetricRecord {
+                    epoch,
+                    step,
+                    loss: batch_loss,
+                    f1: batch_f1_avg,
+                    lr: last_lr,
+                    kind: "batch",
+                });
+            }
+        }
+        let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
+        pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
+        if let Some(l) = &mut logger {
+            l.log(&MetricRecord {
+                epoch,
+                step,
+                loss: last_loss,
+                f1: avg_f1,
+                lr: last_lr,
+                kind: "epoch",
+            });
+        }
+        pb.inc(1);
+    }
+
+    pb.finish_with_message("training done");
+    println!("Total matrix ops: {}", math::matrix_ops_count());
+    let peak = memory::peak_memory_bytes();
+    println!("Max memory usage: {:.2} MB", peak as f64 / (1024.0 * 1024.0));
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,10 +3,12 @@ pub mod decoder;
 pub mod cnn;
 pub mod large_concept;
 pub mod vae;
+pub mod resnet;
 
 pub use encoder::{EncoderLayerT, EncoderT};
 pub use decoder::{DecoderLayerT, DecoderT};
 pub use cnn::SimpleCNN;
 pub use large_concept::LargeConceptModel;
 pub use vae::VAE;
+pub use resnet::ResNet;
 

--- a/src/models/resnet.rs
+++ b/src/models/resnet.rs
@@ -1,0 +1,142 @@
+use crate::math::{self, Matrix};
+use crate::rng::rng_from_env;
+use rand::Rng;
+
+struct ResidualBlock {
+    w1: Matrix,
+    b1: Vec<f32>,
+    w2: Matrix,
+    b2: Vec<f32>,
+}
+
+/// A very small fully connected ResNet-like model.
+///
+/// The network projects the 28x28 input image into a hidden dimension
+/// and applies a sequence of residual blocks before a final linear layer.
+/// The number of residual blocks and the hidden dimension are configurable.
+pub struct ResNet {
+    input: Matrix,
+    input_bias: Vec<f32>,
+    blocks: Vec<ResidualBlock>,
+    fc: Matrix,
+    bias: Vec<f32>,
+}
+
+impl ResidualBlock {
+    fn new(depth: usize, rng: &mut impl Rng) -> Self {
+        let mut w1 = vec![0.0; depth * depth];
+        let mut w2 = vec![0.0; depth * depth];
+        for w in w1.iter_mut().chain(w2.iter_mut()) {
+            *w = rng.gen_range(-0.01..0.01);
+        }
+        let b1 = vec![0.0; depth];
+        let b2 = vec![0.0; depth];
+        Self {
+            w1: Matrix::from_vec(depth, depth, w1),
+            b1,
+            w2: Matrix::from_vec(depth, depth, w2),
+            b2,
+        }
+    }
+}
+
+impl ResNet {
+    /// Create a new [`ResNet`].
+    ///
+    /// `num_classes` controls the number of output classes.
+    /// `depth` sets the hidden dimension of the residual blocks.
+    /// `num_blocks` configures how many residual blocks are stacked.
+    pub fn new(num_classes: usize, depth: usize, num_blocks: usize) -> Self {
+        let mut rng = rng_from_env();
+        // Project the 28x28 input to the hidden dimension.
+        let mut w_in = vec![0.0; 28 * 28 * depth];
+        for w in &mut w_in {
+            *w = rng.gen_range(-0.01..0.01);
+        }
+        let input = Matrix::from_vec(28 * 28, depth, w_in);
+        let input_bias = vec![0.0; depth];
+
+        let mut blocks = Vec::new();
+        for _ in 0..num_blocks {
+            blocks.push(ResidualBlock::new(depth, &mut rng));
+        }
+
+        // Final classification layer.
+        let mut w_out = vec![0.0; depth * num_classes];
+        for w in &mut w_out {
+            *w = rng.gen_range(-0.01..0.01);
+        }
+        let fc = Matrix::from_vec(depth, num_classes, w_out);
+        let bias = vec![0.0; num_classes];
+
+        Self {
+            input,
+            input_bias,
+            blocks,
+            fc,
+            bias,
+        }
+    }
+
+    /// Forward pass returning the hidden feature vector and logits.
+    pub fn forward(&self, img: &[u8]) -> (Vec<f32>, Vec<f32>) {
+        let mut x = vec![0.0f32; self.input.rows];
+        for (i, v) in x.iter_mut().enumerate() {
+            *v = img[i] as f32 / 255.0;
+        }
+
+        // Input projection.
+        let mut h = vec![0.0f32; self.input.cols];
+        for o in 0..self.input.cols {
+            let mut sum = self.input_bias[o];
+            for i in 0..self.input.rows {
+                sum += x[i] * self.input.get(i, o);
+            }
+            h[o] = if sum > 0.0 { sum } else { 0.0 };
+        }
+
+        // Residual blocks.
+        for blk in &self.blocks {
+            let mut z1 = vec![0.0f32; h.len()];
+            for o in 0..h.len() {
+                let mut sum = blk.b1[o];
+                for i in 0..h.len() {
+                    sum += h[i] * blk.w1.get(i, o);
+                }
+                z1[o] = if sum > 0.0 { sum } else { 0.0 };
+            }
+
+            let mut z2 = vec![0.0f32; h.len()];
+            for o in 0..h.len() {
+                let mut sum = blk.b2[o];
+                for i in 0..h.len() {
+                    sum += z1[i] * blk.w2.get(i, o);
+                }
+                z2[o] = sum + h[o];
+            }
+
+            for i in 0..h.len() {
+                h[i] = if z2[i] > 0.0 { z2[i] } else { 0.0 };
+            }
+        }
+
+        // Final linear layer.
+        let feat = h;
+        let mut logits = vec![0.0f32; self.fc.cols];
+        for o in 0..self.fc.cols {
+            let mut sum = self.bias[o];
+            for i in 0..self.fc.rows {
+                sum += feat[i] * self.fc.get(i, o);
+            }
+            logits[o] = sum;
+        }
+        math::inc_ops_by(self.fc.rows * self.fc.cols * 2);
+        (feat, logits)
+    }
+
+    /// Mutable access to the final classification layer parameters.
+    pub fn parameters_mut(&mut self) -> (&mut Matrix, &mut Vec<f32>) {
+        (&mut self.fc, &mut self.bias)
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement configurable ResNet model with residual blocks
- expose ResNet in models module and add training binary
- extend run.sh to train the new model

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7f04a38c832fa927ad2feae022df