### PR TITLE
Add RNN model and training hooks

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 {download|predict|train-backprop|train-elmo|train-noprop|train-lcm|train-resnet} [model] [opt] [--moe] [--num-experts N]" >&2
+  echo "Usage: $0 {download|predict|predict-rnn|train-backprop|train-elmo|train-noprop|train-lcm|train-resnet|train-rnn} [model] [opt] [--moe] [--num-experts N]" >&2
   exit 1
 }
 
@@ -17,6 +17,10 @@ case "$1" in
   predict)
     shift
     cargo run --bin main -- predict "$@"
+    ;;
+  predict-rnn)
+    shift
+    cargo run --bin main -- predict-rnn "$@"
     ;;
   train-backprop)
     shift
@@ -37,6 +41,10 @@ case "$1" in
   train-resnet)
     shift
     cargo run --bin train_resnet -- "$@"
+    ;;
+  train-rnn)
+    shift
+    cargo run --bin main -- train-rnn "$@"
     ;;
   *)
     usage

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,7 +7,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: {} <mode>", args[0]);
-        eprintln!("Modes: predict | download | train-backprop | train-elmo | train-noprop | train-lcm");
+        eprintln!("Modes: predict | predict-rnn | download | train-backprop | train-elmo | train-noprop | train-lcm | train-rnn");
         return;
     }
 
@@ -34,12 +34,30 @@ fn main() {
             };
             predict::run(model_opt, moe, num_experts);
         }
+        "predict-rnn" => {
+            let (
+                _model,
+                _opt,
+                moe,
+                num_experts,
+                _lr_cfg,
+                _resume,
+                _save_every,
+                _ckpt_dir,
+                _log_dir,
+                _experiment,
+                _config,
+                _positional,
+            ) = common::parse_cli(args[2..].iter().cloned());
+            predict::run(Some("rnn"), moe, num_experts);
+        }
         "download" => data::download_mnist(),
-        "train-backprop" | "train-elmo" | "train-noprop" | "train-lcm" => {
+        "train-backprop" | "train-elmo" | "train-noprop" | "train-lcm" | "train-rnn" => {
             let bin = match args[1].as_str() {
                 "train-backprop" => "train_backprop",
                 "train-elmo" => "train_elmo",
                 "train-lcm" => "train_lcm",
+                "train-rnn" => "train_rnn",
                 _ => "train_noprop",
             };
             let status = Command::new("cargo")

--- a/src/bin/train_rnn.rs
+++ b/src/bin/train_rnn.rs
@@ -1,0 +1,95 @@
+use std::env;
+
+use indicatif::ProgressBar;
+use vanillanoprop::config::Config;
+use vanillanoprop::data::load_batches;
+use vanillanoprop::logging::{Logger, MetricRecord};
+use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::metrics::f1_score;
+use vanillanoprop::models::RNN;
+use vanillanoprop::optim::Adam;
+use vanillanoprop::weights::save_rnn;
+
+mod common;
+
+fn main() {
+    let (
+        _model,
+        _opt,
+        _moe,
+        _num_experts,
+        _lr_cfg,
+        _resume,
+        _save_every,
+        _ckpt_dir,
+        log_dir,
+        experiment,
+        config,
+        _,
+    ) = common::parse_cli(env::args().skip(1));
+
+    run(log_dir, experiment, &config);
+}
+
+fn run(log_dir: Option<String>, experiment: Option<String>, config: &Config) {
+    let batches = load_batches(config.batch_size);
+    let vocab_size = 256; // pixel values 0-255
+    let hidden_dim = 64;
+    let num_classes = 10;
+    let mut model = RNN::new_gru(vocab_size, hidden_dim, num_classes);
+
+    let lr = 0.001;
+    let beta1 = 0.9;
+    let beta2 = 0.999;
+    let eps = 1e-8;
+    let weight_decay = 0.0;
+    let mut optim = Adam::new(lr, beta1, beta2, eps, weight_decay);
+
+    let mut logger = Logger::new(log_dir, experiment).ok();
+    let epochs = config.epochs;
+    let pb = ProgressBar::new(epochs as u64);
+    let mut step = 0usize;
+
+    for epoch in 0..epochs {
+        let mut last_loss = 0.0;
+        for batch in &batches {
+            model.zero_grad();
+            let mut batch_loss = 0.0f32;
+            let mut batch_f1 = 0.0f32;
+            for (src, tgt) in batch {
+                // one-hot encode image sequence
+                let mut x = Matrix::zeros(src.len(), vocab_size);
+                for (i, &tok) in src.iter().enumerate() {
+                    x.set(i, tok as usize, 1.0);
+                }
+                let logits = model.forward_train(&x);
+                let (loss, grad, preds) = math::softmax_cross_entropy(&logits, &[*tgt], 0);
+                batch_loss += loss;
+                model.backward(&grad);
+                let f1 = f1_score(&preds, &[*tgt]);
+                batch_f1 += f1;
+            }
+            let bsz = batch.len() as f32;
+            batch_loss /= bsz;
+            batch_f1 /= bsz;
+            last_loss = batch_loss;
+            let mut params = model.parameters();
+            optim.step(&mut params);
+            println!("loss {batch_loss:.4} f1 {batch_f1:.4}");
+            if let Some(l) = &mut logger {
+                l.log(&MetricRecord { epoch, step, loss: batch_loss, f1: batch_f1, lr, kind: "batch" });
+            }
+            step += 1;
+        }
+        pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
+        if let Some(l) = &mut logger {
+            l.log(&MetricRecord { epoch, step, loss: last_loss, f1: 0.0, lr, kind: "epoch" });
+        }
+        pb.inc(1);
+    }
+    pb.finish_with_message("training done");
+
+    if let Err(e) = save_rnn("rnn.json", &mut model) {
+        eprintln!("Failed to save model: {e}");
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod cnn;
 pub mod large_concept;
 pub mod vae;
 pub mod resnet;
+pub mod rnn;
 
 pub use encoder::{EncoderLayerT, EncoderT};
 pub use decoder::{DecoderLayerT, DecoderT};
@@ -11,4 +12,5 @@ pub use cnn::SimpleCNN;
 pub use large_concept::LargeConceptModel;
 pub use vae::VAE;
 pub use resnet::ResNet;
+pub use rnn::RNN;
 

--- a/src/models/rnn.rs
+++ b/src/models/rnn.rs
@@ -1,0 +1,123 @@
+use crate::layers::{LinearT, LSTM, GRU};
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// Reusable RNN encoder/decoder built from an LSTM or GRU cell.
+///
+/// The struct exposes a common interface so higher level code can train or
+/// run inference without needing to know the specific recurrent cell used.
+#[allow(clippy::upper_case_acronyms)]
+pub enum RnnCell {
+    /// Long Short-Term Memory cell
+    LSTM(LSTM),
+    /// Gated Recurrent Unit cell
+    GRU(GRU),
+}
+
+/// Simple RNN model composed of a recurrent cell followed by a linear
+/// projection to the desired output dimension.
+pub struct RNN {
+    pub cell: RnnCell,
+    pub fc: LinearT,
+    last_seq_len: usize,
+}
+
+impl RNN {
+    /// Create a new RNN using an LSTM cell.
+    pub fn new_lstm(input_dim: usize, hidden_dim: usize, output_dim: usize) -> Self {
+        Self {
+            cell: RnnCell::LSTM(LSTM::new(input_dim, hidden_dim)),
+            fc: LinearT::new(hidden_dim, output_dim),
+            last_seq_len: 0,
+        }
+    }
+
+    /// Create a new RNN using a GRU cell.
+    pub fn new_gru(input_dim: usize, hidden_dim: usize, output_dim: usize) -> Self {
+        Self {
+            cell: RnnCell::GRU(GRU::new(input_dim, hidden_dim)),
+            fc: LinearT::new(hidden_dim, output_dim),
+            last_seq_len: 0,
+        }
+    }
+
+    /// Forward pass for inference. `x` is a sequence represented as a matrix
+    /// where each row is a time step.
+    pub fn forward(&self, x: &Tensor) -> Tensor {
+        let h = match &self.cell {
+            RnnCell::LSTM(l) => l.forward(x),
+            RnnCell::GRU(g) => g.forward(x),
+        };
+        // take last hidden state
+        let last_row = h.data.rows - 1;
+        let mut last = Matrix::zeros(1, h.data.cols);
+        for c in 0..h.data.cols {
+            last.set(0, c, h.data.get(last_row, c));
+        }
+        self.fc.forward(&Tensor::from_matrix(last))
+    }
+
+    /// Training forward pass.
+    pub fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        let h = match &mut self.cell {
+            RnnCell::LSTM(l) => l.forward_train(x),
+            RnnCell::GRU(g) => g.forward_train(x),
+        };
+        self.last_seq_len = h.rows;
+        let last = Matrix::from_vec(1, h.cols, h.data[(h.rows - 1) * h.cols..].to_vec());
+        self.fc.forward_train(&last)
+    }
+
+    /// Backward pass through the linear projection and the recurrent cell.
+    pub fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        let grad_last = self.fc.backward(grad_out);
+        let hidden_dim = grad_last.cols;
+        let mut grad_seq = Matrix::zeros(self.last_seq_len, hidden_dim);
+        for c in 0..hidden_dim {
+            grad_seq.set(self.last_seq_len - 1, c, grad_last.get(0, c));
+        }
+        match &mut self.cell {
+            RnnCell::LSTM(l) => l.backward(&grad_seq),
+            RnnCell::GRU(g) => g.backward(&grad_seq),
+        }
+    }
+
+    pub fn zero_grad(&mut self) {
+        match &mut self.cell {
+            RnnCell::LSTM(l) => l.zero_grad(),
+            RnnCell::GRU(g) => g.zero_grad(),
+        }
+        self.fc.zero_grad();
+    }
+
+    /// Feedback alignment style update.
+    pub fn fa_update(&mut self, grad_out: &Matrix, lr: f32) -> Matrix {
+        let grad_last = self.fc.fa_update(grad_out, lr);
+        let hidden_dim = grad_last.cols;
+        let mut grad_seq = Matrix::zeros(self.last_seq_len, hidden_dim);
+        for c in 0..hidden_dim {
+            grad_seq.set(self.last_seq_len - 1, c, grad_last.get(0, c));
+        }
+        match &mut self.cell {
+            RnnCell::LSTM(l) => l.fa_update(&grad_seq, lr),
+            RnnCell::GRU(g) => g.fa_update(&grad_seq, lr),
+        }
+    }
+
+    pub fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
+        match &mut self.cell {
+            RnnCell::LSTM(l) => l.adam_step(lr, beta1, beta2, eps, weight_decay),
+            RnnCell::GRU(g) => g.adam_step(lr, beta1, beta2, eps, weight_decay),
+        }
+        self.fc.adam_step(lr, beta1, beta2, eps, weight_decay);
+    }
+
+    pub fn parameters(&mut self) -> Vec<&mut LinearT> {
+        let mut params = match &mut self.cell {
+            RnnCell::LSTM(l) => l.parameters(),
+            RnnCell::GRU(g) => g.parameters(),
+        };
+        params.extend(self.fc.parameters());
+        params
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce reusable RNN model wrapping LSTM/GRU cells
- Add `train_rnn` binary and wire CLI/run script for `train-rnn` and `predict-rnn`
- Support RNN weight save/load and prediction path

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae825e41d0832faf1ec9d82bfa426c