### PR TITLE
Add TreePo training example and dispatch

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,7 +7,9 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: {} <mode>", args[0]);
-        eprintln!("Modes: predict | predict-rnn | download | train-backprop | train-elmo | train-noprop | train-lcm | train-rnn");
+        eprintln!(
+            "Modes: predict | predict-rnn | download | train-backprop | train-elmo | train-noprop | train-lcm | train-rnn | train-treepo",
+        );
         return;
     }
 
@@ -52,12 +54,14 @@ fn main() {
             predict::run(Some("rnn"), moe, num_experts);
         }
         "download" => data::download_mnist(),
-        "train-backprop" | "train-elmo" | "train-noprop" | "train-lcm" | "train-rnn" => {
+        "train-backprop" | "train-elmo" | "train-noprop" | "train-lcm" | "train-rnn"
+        | "train-treepo" => {
             let bin = match args[1].as_str() {
                 "train-backprop" => "train_backprop",
                 "train-elmo" => "train_elmo",
                 "train-lcm" => "train_lcm",
                 "train-rnn" => "train_rnn",
+                "train-treepo" => "train_treepo",
                 _ => "train_noprop",
             };
             let status = Command::new("cargo")

--- a/src/bin/train_treepo.rs
+++ b/src/bin/train_treepo.rs
@@ -1,0 +1,70 @@
+use rand::Rng;
+use vanillanoprop::rl::treepo::TreeNode;
+use vanillanoprop::rl::{Env, TreePoAgent};
+
+struct LineWorld {
+    position: i32,
+    goal: i32,
+}
+
+impl Env for LineWorld {
+    type State = i32;
+    type Action = i32;
+
+    fn reset(&mut self) -> Self::State {
+        self.position = 0;
+        self.position
+    }
+
+    fn step(&mut self, action: Self::Action) -> (Self::State, f32) {
+        self.position += action;
+        let reward = if self.position == self.goal {
+            1.0
+        } else {
+            -0.01
+        };
+        (self.position, reward)
+    }
+
+    fn is_terminal(&self) -> bool {
+        self.position == self.goal || self.position <= -self.goal
+    }
+}
+
+fn main() {
+    let env = LineWorld {
+        position: 0,
+        goal: 5,
+    };
+    let mut agent = TreePoAgent::new(env, 0.9);
+    let actions = [-1, 1];
+    let mut rng = rand::thread_rng();
+    let episodes = 10;
+
+    for episode in 0..episodes {
+        let state = agent.env.reset();
+        agent.root.state = state;
+        agent.root.value = 0.0;
+        agent.root.visits = 0;
+        agent.root.children.clear();
+        loop {
+            let action = actions[rng.gen_range(0..actions.len())];
+            let (next_state, reward) = agent.env.step(action);
+            {
+                use std::collections::HashMap;
+                let child = agent.root.children.entry(action).or_insert(TreeNode {
+                    state: next_state,
+                    value: 0.0,
+                    visits: 0,
+                    children: HashMap::new(),
+                });
+                TreePoAgent::<LineWorld>::backup(child, reward);
+            }
+            agent.update_policy();
+            if agent.env.is_terminal() {
+                break;
+            }
+        }
+        println!("Episode {} complete", episode + 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `train_treepo` binary demonstrating `TreePoAgent`
- allow running the new binary via `train-treepo` mode in `main`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae890a8a54832fa3b02ddb914f054c