### PR TITLE
Add build script compiling C sources with ARM flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,8 +946,10 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 name = "vanillanoprop"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "criterion",
  "csv",
+ "glob",
  "indicatif",
  "libc",
  "mnist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ path = "src/bin/sample_vae.rs"
 [dev-dependencies]
 criterion = "0.5"
 
+[build-dependencies]
+cc = "1.0"
+glob = "0.3"
+
 [[bench]]
 name = "mask_topk"
 harness = false

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use glob::glob;
+
+fn main() {
+    let mut build = cc::Build::new();
+    for entry in glob("c_src/*.c").expect("failed to read glob pattern") {
+        build.file(entry.expect("invalid path"));
+    }
+
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("armv7") {
+        build.flag("-mcpu=cortex-a7");
+    } else if target.contains("aarch64") || target.contains("arm64") {
+        build.flag("-march=armv8-a");
+    } else if target.starts_with("arm") {
+        build.flag("-march=armv7-a");
+    }
+
+    build.compile("c_src");
+}


### PR DESCRIPTION
## Summary
- compile C sources in `c_src/` via new `build.rs`
- add ARM-specific compilation flags depending on target
- declare `cc` and `glob` build dependencies

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b04173e19c832f8e74d0add292878e