### PR TITLE
Add optional Kai backend feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "vanillanoprop"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
+
+[features]
+default = []
+kai = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,10 @@ use std::env;
 use glob::glob;
 
 fn main() {
+    if env::var("CARGO_FEATURE_KAI").is_err() {
+        return;
+    }
+
     let mut build = cc::Build::new();
     for entry in glob("c_src/*.c").expect("failed to read glob pattern") {
         build.file(entry.expect("invalid path"));

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,8 +1,8 @@
 use crate::math::{matmul_cpu, Matrix};
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kai"))]
 use crate::math::{inc_add_ops_by, inc_mul_ops_by};
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kai"))]
 use crate::ffi::kai::kai_matmul;
 
 /// Abstraction over a compute device capable of executing matrix operations.
@@ -22,11 +22,11 @@ impl Device for Cpu {
 }
 
 /// [`Device`] backed by the Kai microkernel over FFI.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kai"))]
 #[derive(Default, Clone, Copy)]
 pub struct KaiDevice;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kai"))]
 impl Device for KaiDevice {
     fn matmul(&self, a: &Matrix, b: &Matrix) -> Matrix {
         assert_eq!(a.cols, b.rows);

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(all(feature = "kai", target_arch = "aarch64"))]
 pub mod kai;


### PR DESCRIPTION
## Summary
- add `kai` feature to conditionally compile Kai microkernel
- wire build script and `cc` build dependency
- guard Kai-specific device and FFI behind `kai` feature on aarch64

## Testing
- `cargo test`
- `cargo test --features kai`


------
https://chatgpt.com/codex/tasks/task_e_68b045c421f0832fba3ea55c611e7115