### PR TITLE
Add model training API using optimizers and metrics

### DIFF
--- a/src/bin/train_lcm.rs
+++ b/src/bin/train_lcm.rs
@@ -1,10 +1,10 @@
 use std::env;
 
 use indicatif::ProgressBar;
-use vanillanoprop::data::load_batches;
-use vanillanoprop::metrics::f1_score;
-use vanillanoprop::models::LargeConceptModel;
 use vanillanoprop::config::Config;
+use vanillanoprop::data::load_batches;
+use vanillanoprop::model::Model;
+use vanillanoprop::models::LargeConceptModel;
 use vanillanoprop::weights::save_lcm;
 
 mod common;
@@ -31,6 +31,7 @@ fn run(config: &Config) {
     let batches = load_batches(config.batch_size);
     let mut model = LargeConceptModel::new(28 * 28, 128, 10);
     let lr = 0.01f32;
+    let evaluator = Model::new();
 
     let pb = ProgressBar::new(config.epochs as u64);
     for epoch in 0..config.epochs {
@@ -43,7 +44,7 @@ fn run(config: &Config) {
             for (img, tgt) in batch {
                 let (loss, pred) = model.train_step(img, *tgt, lr);
                 batch_loss += loss;
-                batch_f1 += f1_score(&[pred], &[*tgt]);
+                batch_f1 += evaluator.evaluate(&[pred], &[*tgt]);
             }
             let bsz = batch.len() as f32;
             batch_loss /= bsz;

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -10,7 +10,7 @@ use vanillanoprop::layers::Activation;
 use vanillanoprop::logging::{Logger, MetricRecord};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::memory;
-use vanillanoprop::metrics::f1_score;
+use vanillanoprop::model::Model;
 use vanillanoprop::models::EncoderT;
 use vanillanoprop::optim::lr_scheduler::{
     ConstantLr, CosineLr, LearningRateSchedule, LrScheduleConfig, StepLr,
@@ -143,6 +143,7 @@ fn run(
 
     let mut logger = Logger::new(log_dir, experiment_name).ok();
     let mut last_lr = base_lr;
+    let evaluator = Model::new();
 
     math::reset_matrix_ops();
     let pb = ProgressBar::new(config.epochs as u64);
@@ -195,7 +196,7 @@ fn run(
                 encoder.fa_update(&delta, lr);
                 step += 1;
                 let src_slice: Vec<usize> = src[..len].iter().map(|&v| v as usize).collect();
-                let f1 = f1_score(&src_slice, &[tgt]);
+                let f1 = evaluator.evaluate(&src_slice, &[tgt]);
                 batch_f1 += f1;
             }
             let bsz = batch.len() as f32;

--- a/src/bin/train_rnn.rs
+++ b/src/bin/train_rnn.rs
@@ -5,9 +5,9 @@ use vanillanoprop::config::Config;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::logging::{Logger, MetricRecord};
 use vanillanoprop::math::{self, Matrix};
-use vanillanoprop::metrics::f1_score;
+use vanillanoprop::model::Model;
 use vanillanoprop::models::RNN;
-use vanillanoprop::optim::Adam;
+use vanillanoprop::optim::{Adam, MseLoss};
 use vanillanoprop::weights::save_rnn;
 
 mod common;
@@ -36,14 +36,18 @@ fn run(log_dir: Option<String>, experiment: Option<String>, config: &Config) {
     let vocab_size = 256; // pixel values 0-255
     let hidden_dim = 64;
     let num_classes = 10;
-    let mut model = RNN::new_gru(vocab_size, hidden_dim, num_classes);
+    let mut rnn = RNN::new_gru(vocab_size, hidden_dim, num_classes);
 
     let lr = 0.001;
     let beta1 = 0.9;
     let beta2 = 0.999;
     let eps = 1e-8;
     let weight_decay = 0.0;
-    let mut optim = Adam::new(lr, beta1, beta2, eps, weight_decay);
+    let mut trainer = Model::new();
+    trainer.compile(
+        Adam::new(lr, beta1, beta2, eps, weight_decay),
+        MseLoss::new(),
+    );
 
     let mut logger = Logger::new(log_dir, experiment).ok();
     let epochs = config.epochs;
@@ -53,7 +57,7 @@ fn run(log_dir: Option<String>, experiment: Option<String>, config: &Config) {
     for epoch in 0..epochs {
         let mut last_loss = 0.0;
         for batch in &batches {
-            model.zero_grad();
+            rnn.zero_grad();
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (src, tgt) in batch {
@@ -62,34 +66,48 @@ fn run(log_dir: Option<String>, experiment: Option<String>, config: &Config) {
                 for (i, &tok) in src.iter().enumerate() {
                     x.set(i, tok as usize, 1.0);
                 }
-                let logits = model.forward_train(&x);
+                let logits = rnn.forward_train(&x);
                 let (loss, grad, preds) = math::softmax_cross_entropy(&logits, &[*tgt], 0);
                 batch_loss += loss;
-                model.backward(&grad);
-                let f1 = f1_score(&preds, &[*tgt]);
+                rnn.backward(&grad);
+                let f1 = trainer.evaluate(&preds, &[*tgt]);
                 batch_f1 += f1;
             }
             let bsz = batch.len() as f32;
             batch_loss /= bsz;
             batch_f1 /= bsz;
             last_loss = batch_loss;
-            let mut params = model.parameters();
-            optim.step(&mut params);
+            let mut params = rnn.parameters();
+            trainer.fit(&mut params);
             println!("loss {batch_loss:.4} f1 {batch_f1:.4}");
             if let Some(l) = &mut logger {
-                l.log(&MetricRecord { epoch, step, loss: batch_loss, f1: batch_f1, lr, kind: "batch" });
+                l.log(&MetricRecord {
+                    epoch,
+                    step,
+                    loss: batch_loss,
+                    f1: batch_f1,
+                    lr,
+                    kind: "batch",
+                });
             }
             step += 1;
         }
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
         if let Some(l) = &mut logger {
-            l.log(&MetricRecord { epoch, step, loss: last_loss, f1: 0.0, lr, kind: "epoch" });
+            l.log(&MetricRecord {
+                epoch,
+                step,
+                loss: last_loss,
+                f1: 0.0,
+                lr,
+                kind: "epoch",
+            });
         }
         pb.inc(1);
     }
     pb.finish_with_message("training done");
 
-    if let Err(e) = save_rnn("rnn.json", &mut model) {
+    if let Err(e) = save_rnn("rnn.json", &mut rnn) {
         eprintln!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_vae.rs
+++ b/src/bin/train_vae.rs
@@ -1,7 +1,8 @@
 use vanillanoprop::data::load_pairs;
 use vanillanoprop::math::{kl_divergence, mse_loss, Matrix};
+use vanillanoprop::model::Model;
 use vanillanoprop::models::VAE;
-use vanillanoprop::optim::Adam;
+use vanillanoprop::optim::{Adam, MseLoss};
 use vanillanoprop::weights::save_vae;
 
 fn main() {
@@ -10,7 +11,8 @@ fn main() {
     let hidden_dim = 400;
     let latent_dim = 20;
     let mut vae = VAE::new(input_dim, hidden_dim, latent_dim);
-    let mut adam = Adam::new(0.001, 0.9, 0.999, 1e-8, 0.0);
+    let mut trainer = Model::new();
+    trainer.compile(Adam::new(0.001, 0.9, 0.999, 1e-8, 0.0), MseLoss::new());
 
     for epoch in 0..3 {
         let mut total = 0.0f32;
@@ -23,7 +25,7 @@ fn main() {
             vae.zero_grad();
             vae.backward(&grad_recon, &grad_mu_kl, &grad_logvar_kl);
             let mut params = vae.parameters();
-            adam.step(&mut params);
+            trainer.fit(&mut params);
             total += recon_loss + kl_loss;
         }
         println!("epoch {epoch} loss {:.4}", total / pairs.len() as f32);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,12 +1,18 @@
 use std::collections::HashMap;
 
-/// A simple directed graph representing a neural network.
+use crate::layers::LinearT;
+use crate::math::Matrix;
+use crate::metrics;
+use crate::optim::{Loss, Optimizer};
+
+/// A simple directed graph representing a neural network together with
+/// minimal training utilities.
 ///
-/// Nodes are stored as strings identifying the layer type or name.
-/// Edges represent data flow between nodes. This structure allows
-/// models to be composed programmatically by adding nodes and
-/// connecting them.
-#[derive(Clone, Default, Debug)]
+/// Nodes are stored as strings identifying the layer type or name. Edges
+/// represent data flow between nodes. This structure allows models to be
+/// composed programmatically by adding nodes and connecting them.  The
+/// optional optimizer and loss are used by the `fit` and `evaluate`
+/// helpers to provide a lightweight training API for examples.
 pub struct Model {
     /// List of node labels in insertion order.
     pub nodes: Vec<String>,
@@ -14,12 +20,71 @@ pub struct Model {
     pub edges: Vec<(usize, usize)>,
     /// Optional metadata for nodes.
     pub metadata: HashMap<usize, HashMap<String, String>>,
+    optimizer: Option<Box<dyn Optimizer>>, // training optimizer
+    loss: Option<Box<dyn Loss>>,           // loss function
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            metadata: HashMap::new(),
+            optimizer: None,
+            loss: None,
+        }
+    }
 }
 
 impl Model {
     /// Create an empty model.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Configure the model for training by providing an optimizer and loss
+    /// function.
+    pub fn compile<O, L>(&mut self, optimizer: O, loss: L)
+    where
+        O: Optimizer + 'static,
+        L: Loss + 'static,
+    {
+        self.optimizer = Some(Box::new(optimizer));
+        self.loss = Some(Box::new(loss));
+    }
+
+    /// Perform a single optimization step on the provided parameters.
+    pub fn fit(&mut self, params: &mut [&mut LinearT]) {
+        if let Some(opt) = &mut self.optimizer {
+            opt.step(params);
+        }
+    }
+
+    /// Mutable access to the underlying optimizer for advanced configuration.
+    pub fn optimizer_mut(&mut self) -> Option<&mut dyn Optimizer> {
+        self.optimizer.as_deref_mut()
+    }
+
+    /// Optimization step for models exposing raw matrices and biases.
+    pub fn fit_fc(&mut self, fc: &mut Matrix, bias: &mut [f32], grad: &[f32], feat: &[f32]) {
+        if let Some(opt) = &mut self.optimizer {
+            opt.update_fc(fc, bias, grad, feat);
+        }
+    }
+
+    /// Evaluate predictions against targets using the F1 score metric.
+    pub fn evaluate(&self, pred: &[usize], tgt: &[usize]) -> f32 {
+        metrics::f1_score(pred, tgt)
+    }
+
+    /// Predict the most likely class from a slice of logits.
+    pub fn predict(&self, logits: &[f32]) -> usize {
+        logits
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i)
+            .unwrap_or(0)
     }
 
     /// Add a node to the model and return its index.
@@ -36,4 +101,3 @@ impl Model {
         self.edges.push((from, to));
     }
 }
-

--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -7,3 +7,109 @@ pub use adam::Adam;
 pub use hrm::Hrm;
 pub use lr_scheduler::{ConstantLr, CosineLr, LearningRateSchedule, LrScheduleConfig, StepLr};
 pub use sgd::SGD;
+
+use crate::layers::LinearT;
+use crate::math::Matrix;
+use std::any::Any;
+
+/// Common interface for optimizers operating on linear layers.
+pub trait Optimizer: Any {
+    /// Update the provided parameters in-place.
+    fn step(&mut self, params: &mut [&mut LinearT]);
+
+    /// Optional update for raw weight matrices and bias vectors.
+    ///
+    /// Implementations can override this to handle cases where the model does
+    /// not expose [`LinearT`] parameters directly.
+    fn update_fc(&mut self, _fc: &mut Matrix, _bias: &mut [f32], _grad: &[f32], _feat: &[f32]) {}
+
+    /// Allow downcasting to concrete types.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl Optimizer for Adam {
+    fn step(&mut self, params: &mut [&mut LinearT]) {
+        Adam::step(self, params);
+    }
+
+    fn update_fc(&mut self, fc: &mut Matrix, bias: &mut [f32], grad: &[f32], feat: &[f32]) {
+        // Basic gradient descent update using Adam's learning rate.
+        let lr = self.lr;
+        for (c, &g) in grad.iter().enumerate() {
+            bias[c] -= lr * g;
+            for (r, &f) in feat.iter().enumerate() {
+                let idx = r * fc.cols + c;
+                fc.data[idx] -= lr * f * g;
+            }
+        }
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Optimizer for SGD {
+    fn step(&mut self, params: &mut [&mut LinearT]) {
+        SGD::step(self, params);
+    }
+
+    fn update_fc(&mut self, fc: &mut Matrix, bias: &mut [f32], grad: &[f32], feat: &[f32]) {
+        let lr = self.lr;
+        for (c, &g) in grad.iter().enumerate() {
+            bias[c] -= lr * g;
+            for (r, &f) in feat.iter().enumerate() {
+                let idx = r * fc.cols + c;
+                fc.data[idx] -= lr * f * g;
+            }
+        }
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Optimizer for Hrm {
+    fn step(&mut self, _params: &mut [&mut LinearT]) {}
+
+    fn update_fc(&mut self, fc: &mut Matrix, bias: &mut [f32], grad: &[f32], feat: &[f32]) {
+        Hrm::update(self, fc, bias, grad, feat);
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Simple loss interface used during training.
+pub trait Loss {
+    /// Compute the scalar loss for the given prediction and target vectors.
+    fn loss(&self, pred: &[f32], target: &[f32]) -> f32;
+}
+
+/// Mean squared error loss.
+pub struct MeanSquaredError;
+
+impl MeanSquaredError {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Loss for MeanSquaredError {
+    fn loss(&self, pred: &[f32], target: &[f32]) -> f32 {
+        let len = pred.len().min(target.len());
+        if len == 0 {
+            return 0.0;
+        }
+        let mut sum = 0.0f32;
+        for i in 0..len {
+            let d = pred[i] - target[i];
+            sum += d * d;
+        }
+        sum / len as f32
+    }
+}
+
+pub use MeanSquaredError as MseLoss;


### PR DESCRIPTION
## Summary
- Introduce Optimizer and Loss traits with MSE loss and unify Adam/SGD/Hrm under a common interface
- Extend Model with compile/fit/evaluate/predict helpers for training and inference
- Refactor training binaries to rely on the new Model API for optimization and metrics

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b065f874a0832f963e22d6e53feeb1