### PR TITLE
Add training callbacks with early stopping and snapshots

### DIFF
--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -4,7 +4,7 @@ use indicatif::ProgressBar;
 use vanillanoprop::config::Config;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::layers::Activation;
-use vanillanoprop::logging::{Logger, MetricRecord};
+use vanillanoprop::logging::{Callback, Logger, MetricRecord};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::memory;
 use vanillanoprop::model::Model;
@@ -42,6 +42,7 @@ fn main() {
             log_dir,
             experiment,
             &config,
+            Vec::<Box<dyn Callback>>::new(),
         );
     } else {
         run(&opt, moe, num_experts, log_dir, experiment, &config);

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -4,7 +4,7 @@ use indicatif::ProgressBar;
 use vanillanoprop::config::Config;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::layers::Activation;
-use vanillanoprop::logging::{Logger, MetricRecord};
+use vanillanoprop::logging::{Callback, Logger, MetricRecord};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::memory;
 use vanillanoprop::model::Model;
@@ -42,6 +42,7 @@ fn main() {
             log_dir,
             experiment,
             &config,
+            Vec::<Box<dyn Callback>>::new(),
         );
     } else {
         run(moe, num_experts, log_dir, experiment, &config);

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use vanillanoprop::config::Config;
 use vanillanoprop::data::load_batches;
 use vanillanoprop::layers::Activation;
-use vanillanoprop::logging::{Logger, MetricRecord};
+use vanillanoprop::logging::{Callback, Logger, MetricRecord};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::memory;
 use vanillanoprop::model::Model;
@@ -51,6 +51,7 @@ fn main() {
             log_dir,
             experiment,
             &config,
+            Vec::<Box<dyn Callback>>::new(),
         );
     } else {
         run(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -56,3 +56,97 @@ impl Logger {
         let _ = self.csv.serialize(metrics);
     }
 }
+
+/// Signals returned by callbacks to control training flow.
+pub enum CallbackSignal {
+    /// Continue training as normal.
+    Continue,
+    /// Stop training early.
+    Stop,
+}
+
+/// Trait for hooking into various stages of the training loop.
+pub trait Callback {
+    /// Called once before training starts.
+    fn on_train_begin(&mut self) {}
+
+    /// Called at the beginning of each epoch.
+    fn on_epoch_begin(&mut self, _epoch: usize) {}
+
+    /// Called after each batch. Returning `Stop` will end training.
+    fn on_batch_end(&mut self, _metrics: &MetricRecord) -> CallbackSignal {
+        CallbackSignal::Continue
+    }
+
+    /// Called after each epoch. Returning `Stop` will end training.
+    fn on_epoch_end(&mut self, _metrics: &MetricRecord) -> CallbackSignal {
+        CallbackSignal::Continue
+    }
+
+    /// Called once after training ends.
+    fn on_train_end(&mut self) {}
+}
+
+/// Stop training when a monitored metric fails to improve.
+pub struct EarlyStopping {
+    patience: usize,
+    best: Option<f32>,
+    wait: usize,
+}
+
+impl EarlyStopping {
+    /// Create a new [`EarlyStopping`] callback monitoring F1 score.
+    pub fn new(patience: usize) -> Self {
+        Self {
+            patience,
+            best: None,
+            wait: 0,
+        }
+    }
+}
+
+impl Callback for EarlyStopping {
+    fn on_epoch_end(&mut self, metrics: &MetricRecord) -> CallbackSignal {
+        let current = metrics.f1;
+        if self.best.map_or(true, |b| current > b) {
+            self.best = Some(current);
+            self.wait = 0;
+        } else {
+            self.wait += 1;
+            if self.wait >= self.patience {
+                return CallbackSignal::Stop;
+            }
+        }
+        CallbackSignal::Continue
+    }
+}
+
+/// Save model snapshots whenever the monitored metric improves.
+pub struct ModelSnapshot {
+    save_fn: Box<dyn FnMut(&MetricRecord)>,
+    best: Option<f32>,
+}
+
+impl ModelSnapshot {
+    /// Create a new [`ModelSnapshot`] with a custom save function.
+    pub fn new<F>(save: F) -> Self
+    where
+        F: FnMut(&MetricRecord) + 'static,
+    {
+        Self {
+            save_fn: Box::new(save),
+            best: None,
+        }
+    }
+}
+
+impl Callback for ModelSnapshot {
+    fn on_epoch_end(&mut self, metrics: &MetricRecord) -> CallbackSignal {
+        let current = metrics.f1;
+        if self.best.map_or(true, |b| current > b) {
+            self.best = Some(current);
+            (self.save_fn)(metrics);
+        }
+        CallbackSignal::Continue
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Callback` trait with training lifecycle hooks
- add `EarlyStopping` and `ModelSnapshot` callbacks
- allow `train_cnn::run` to accept callbacks and trigger them during training

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b09fe41104832f95bcbcb36bdd5216