### PR TITLE
Add CNN, RNN, and autoencoder examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,27 @@ cargo run --example load_config
 ```
 
 Loads training parameters from `lcm_config.toml` and falls back to defaults if the file is not found.
+
+### MNIST CNN
+
+```bash
+cargo run --example mnist_cnn
+```
+
+Trains a simple convolutional network on the MNIST digits using the dataset utilities.
+
+### RNN text classification
+
+```bash
+cargo run --example text_rnn
+```
+
+Shows how to build a tiny LSTM classifier on a toy text dataset.
+
+### Autoencoder
+
+```bash
+cargo run --example autoencoder
+```
+
+Runs a small variational autoencoder to reconstruct MNIST images.

--- a/examples/autoencoder.rs
+++ b/examples/autoencoder.rs
@@ -1,0 +1,48 @@
+use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::math::Matrix;
+use vanillanoprop::models::VAE;
+
+fn main() {
+    // Use dataset utilities to load MNIST in mini-batches
+    let batches = Mnist::batch(16);
+    let mut vae = VAE::new(28 * 28, 128, 32);
+
+    for (i, batch) in batches.iter().take(3).enumerate() {
+        let mut loss_sum = 0.0f32;
+        for (img, _) in batch {
+            let input: Vec<f32> = img.iter().map(|&p| p as f32 / 255.0).collect();
+            let x = Matrix::from_vec(1, input.len(), input);
+            let (recon, mu, logvar) = vae.forward_train(&x);
+
+            // reconstruction loss (MSE)
+            let mut recon_grad = Matrix::zeros(recon.rows, recon.cols);
+            let mut recon_loss = 0.0f32;
+            for j in 0..recon.data.len() {
+                let diff = recon.data[j] - x.data[j];
+                recon_loss += diff * diff;
+                recon_grad.data[j] = 2.0 * diff / recon.data.len() as f32;
+            }
+
+            // KL divergence gradients
+            let mut grad_mu = Matrix::zeros(mu.rows, mu.cols);
+            let mut grad_logvar = Matrix::zeros(logvar.rows, logvar.cols);
+            let mut kl = 0.0f32;
+            for j in 0..mu.data.len() {
+                let m = mu.data[j];
+                let lv = logvar.data[j];
+                kl += -0.5 * (1.0 + lv - m * m - lv.exp());
+                grad_mu.data[j] = m;
+                grad_logvar.data[j] = 0.5 * (lv.exp() - 1.0);
+            }
+
+            vae.zero_grad();
+            vae.backward(&recon_grad, &grad_mu, &grad_logvar);
+            for p in vae.parameters() {
+                p.adam_step(0.001, 0.9, 0.999, 1e-8, 0.0);
+            }
+
+            loss_sum += recon_loss / recon.data.len() as f32 + kl / mu.data.len() as f32;
+        }
+        println!("batch {i} loss {}", loss_sum / batch.len() as f32);
+    }
+}

--- a/examples/mnist_cnn.rs
+++ b/examples/mnist_cnn.rs
@@ -1,0 +1,39 @@
+use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::models::SimpleCNN;
+
+fn main() {
+    // Load MNIST and group into mini-batches using the Dataset API.
+    let batches = Mnist::batch(32);
+    let mut cnn = SimpleCNN::new(10);
+    let lr = 0.01f32;
+
+    for (i, batch) in batches.iter().take(5).enumerate() {
+        let mut loss_sum = 0.0f32;
+        for (img, label) in batch {
+            let (feat, logits) = cnn.forward(img);
+            let logits_m = Matrix::from_vec(1, logits.len(), logits);
+            let (loss, grad, _) = math::softmax_cross_entropy(&logits_m, &[*label as usize], 0);
+            loss_sum += loss;
+
+            // Simple SGD update
+            let grad_logits = grad.data;
+            let (fc, bias) = cnn.parameters_mut();
+            let rows = fc.rows;
+            let cols = fc.cols;
+            let mut grad_matrix = vec![0.0f32; rows * cols];
+            for (c, &g) in grad_logits.iter().enumerate() {
+                for (r, &f) in feat.iter().enumerate() {
+                    grad_matrix[r * cols + c] = f * g;
+                }
+            }
+            for (w, &g) in fc.data.iter_mut().zip(grad_matrix.iter()) {
+                *w -= lr * g;
+            }
+            for (b, &g) in bias.iter_mut().zip(grad_logits.iter()) {
+                *b -= lr * g;
+            }
+        }
+        println!("batch {i} loss {}", loss_sum / batch.len() as f32);
+    }
+}

--- a/examples/text_rnn.rs
+++ b/examples/text_rnn.rs
@@ -1,0 +1,40 @@
+use vanillanoprop::data::Dataset;
+use vanillanoprop::math::{self, Matrix};
+use vanillanoprop::models::RNN;
+
+// Tiny in-memory dataset of sequences with binary labels.
+struct ToyText;
+
+impl Dataset for ToyText {
+    type Item = (Vec<Vec<f32>>, u8);
+
+    fn load() -> Vec<Self::Item> {
+        vec![
+            (vec![vec![1.0], vec![2.0], vec![3.0]], 1),
+            (vec![vec![3.0], vec![2.0], vec![1.0]], 0),
+            (vec![vec![0.5], vec![1.5], vec![0.5]], 1),
+            (vec![vec![1.5], vec![0.5], vec![1.5]], 0),
+        ]
+    }
+}
+
+fn main() {
+    let batches = ToyText::batch(2);
+    let mut rnn = RNN::new_lstm(1, 4, 2);
+
+    for (i, batch) in batches.iter().enumerate() {
+        for (seq, label) in batch {
+            // Convert sequence to Matrix (time_steps x input_dim)
+            let mut mat = Matrix::zeros(seq.len(), 1);
+            for (t, token) in seq.iter().enumerate() {
+                mat.set(t, 0, token[0]);
+            }
+            let logits = rnn.forward_train(&mat);
+            let (loss, grad, _) = math::softmax_cross_entropy(&logits, &[*label as usize], 0);
+            rnn.zero_grad();
+            rnn.backward(&grad);
+            rnn.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
+            println!("batch {i} sample loss {loss}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MNIST CNN example using Dataset API
- add toy RNN text classifier example
- add MNIST autoencoder example
- document how to run examples in README

## Testing
- `cargo test`
- `cargo run --example text_rnn`
- `cargo run --example mnist_cnn` *(fails: invalid gzip header)*
- `cargo run --example autoencoder` *(fails: invalid gzip header)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b79d05d4832fa0fbb5d92e5080cc