### PR TITLE
Add simple GAN model with training example

### DIFF
--- a/examples/mnist_gan.rs
+++ b/examples/mnist_gan.rs
@@ -1,0 +1,29 @@
+use rand::Rng;
+use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::math::Matrix;
+use vanillanoprop::models::GAN;
+use vanillanoprop::rng::rng_from_env;
+
+fn main() {
+    let batches = Mnist::batch(32);
+    let mut gan = GAN::new(100);
+    let mut rng = rng_from_env();
+    for (i, batch) in batches.iter().take(2).enumerate() {
+        let mut d_loss_sum = 0.0f32;
+        let mut g_loss_sum = 0.0f32;
+        for (img, _) in batch {
+            let real: Vec<f32> = img.iter().map(|&p| p as f32 / 255.0).collect();
+            let real_m = Matrix::from_vec(1, real.len(), real);
+            let noise: Vec<f32> = (0..100).map(|_| rng.gen::<f32>() * 2.0 - 1.0).collect();
+            let noise_m = Matrix::from_vec(1, 100, noise);
+            let (d_loss, g_loss) = gan.train_step(&real_m, &noise_m, 0.0002);
+            d_loss_sum += d_loss;
+            g_loss_sum += g_loss;
+        }
+        println!(
+            "batch {i} d_loss {} g_loss {}",
+            d_loss_sum / batch.len() as f32,
+            g_loss_sum / batch.len() as f32
+        );
+    }
+}

--- a/src/models/gan.rs
+++ b/src/models/gan.rs
@@ -1,0 +1,157 @@
+use crate::layers::conv::Conv2d;
+use crate::layers::layer::Layer;
+use crate::layers::linear::LinearT;
+use crate::layers::{leaky_relu, relu, sigmoid, tanh};
+use crate::math::Matrix;
+
+pub struct Generator {
+    pub fc1: LinearT,
+    pub fc2: LinearT,
+    mask: Vec<f32>,
+    out_cache: Matrix,
+}
+
+impl Generator {
+    pub fn new(latent_dim: usize, hidden_dim: usize, output_dim: usize) -> Self {
+        Self {
+            fc1: LinearT::new(latent_dim, hidden_dim),
+            fc2: LinearT::new(hidden_dim, output_dim),
+            mask: Vec::new(),
+            out_cache: Matrix::zeros(0, 0),
+        }
+    }
+
+    pub fn forward_train(&mut self, z: &Matrix) -> Matrix {
+        let mut h = self.fc1.forward_train(z);
+        self.mask = relu::forward_matrix(&mut h);
+        let mut out = self.fc2.forward_train(&h);
+        tanh::forward_matrix(&mut out);
+        self.out_cache = out.clone();
+        out
+    }
+
+    pub fn backward(&mut self, grad_out: &Matrix) {
+        let mut g = grad_out.clone();
+        tanh::backward(&mut g, &self.out_cache);
+        let grad_h = self.fc2.backward(&g);
+        let mut grad_h_act = grad_h.clone();
+        relu::backward(&mut grad_h_act, &self.mask);
+        self.fc1.backward(&grad_h_act);
+    }
+
+    pub fn zero_grad(&mut self) {
+        self.fc1.zero_grad();
+        self.fc2.zero_grad();
+    }
+
+    pub fn parameters(&mut self) -> Vec<&mut LinearT> {
+        vec![&mut self.fc1, &mut self.fc2]
+    }
+}
+
+pub struct Discriminator {
+    pub conv: Conv2d,
+    pub fc: LinearT,
+    mask: Vec<f32>,
+}
+
+impl Discriminator {
+    pub fn new() -> Self {
+        Self {
+            conv: Conv2d::new(1, 4, 3, 2, 1),
+            fc: LinearT::new(4 * 14 * 14, 1),
+            mask: Vec::new(),
+        }
+    }
+
+    pub fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        let mut h = self.conv.forward_train(x);
+        self.mask = leaky_relu::forward_matrix(&mut h);
+        self.fc.forward_train(&h)
+    }
+
+    pub fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        let grad_fc = self.fc.backward(grad_out);
+        let mut grad_h = grad_fc.clone();
+        leaky_relu::backward(&mut grad_h, &self.mask);
+        self.conv.backward(&grad_h)
+    }
+
+    pub fn zero_grad(&mut self) {
+        self.conv.zero_grad();
+        self.fc.zero_grad();
+    }
+
+    pub fn parameters(&mut self) -> Vec<&mut LinearT> {
+        let mut params = self.conv.parameters();
+        params.push(&mut self.fc);
+        params
+    }
+}
+
+pub struct GAN {
+    pub generator: Generator,
+    pub discriminator: Discriminator,
+}
+
+impl GAN {
+    pub fn new(latent_dim: usize) -> Self {
+        Self {
+            generator: Generator::new(latent_dim, 128, 28 * 28),
+            discriminator: Discriminator::new(),
+        }
+    }
+
+    pub fn train_step(&mut self, real: &Matrix, noise: &Matrix, lr: f32) -> (f32, f32) {
+        // Train discriminator
+        self.discriminator.zero_grad();
+        let fake = self.generator.forward_train(noise);
+        let real_logits = self.discriminator.forward_train(real);
+        let fake_logits = self.discriminator.forward_train(&fake);
+        let mut real_prob = real_logits.clone();
+        sigmoid::forward_matrix(&mut real_prob);
+        let mut fake_prob = fake_logits.clone();
+        sigmoid::forward_matrix(&mut fake_prob);
+        let mut grad_real = Matrix::zeros(real_logits.rows, real_logits.cols);
+        let mut grad_fake = Matrix::zeros(fake_logits.rows, fake_logits.cols);
+        let mut d_loss = 0.0f32;
+        for i in 0..real_prob.data.len() {
+            let p = real_prob.data[i];
+            d_loss += -(p + 1e-9).ln();
+            grad_real.data[i] = p - 1.0;
+        }
+        for i in 0..fake_prob.data.len() {
+            let p = fake_prob.data[i];
+            d_loss += -((1.0 - p) + 1e-9).ln();
+            grad_fake.data[i] = p;
+        }
+        d_loss /= (real_prob.data.len() + fake_prob.data.len()) as f32;
+        self.discriminator.backward(&grad_real);
+        self.discriminator.backward(&grad_fake);
+        for p in self.discriminator.parameters() {
+            p.sgd_step(lr, 0.0);
+        }
+
+        // Train generator
+        self.generator.zero_grad();
+        self.discriminator.zero_grad();
+        let fake = self.generator.forward_train(noise);
+        let fake_logits = self.discriminator.forward_train(&fake);
+        let mut fake_prob = fake_logits.clone();
+        sigmoid::forward_matrix(&mut fake_prob);
+        let mut grad = Matrix::zeros(fake_logits.rows, fake_logits.cols);
+        let mut g_loss = 0.0f32;
+        for i in 0..fake_prob.data.len() {
+            let p = fake_prob.data[i];
+            g_loss += -(p + 1e-9).ln();
+            grad.data[i] = p - 1.0;
+        }
+        let grad_input = self.discriminator.backward(&grad);
+        self.generator.backward(&grad_input);
+        for p in self.generator.parameters() {
+            p.sgd_step(lr, 0.0);
+        }
+        g_loss /= fake_prob.data.len() as f32;
+        (d_loss, g_loss)
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,20 +1,21 @@
-pub mod encoder;
-pub mod decoder;
 pub mod cnn;
+pub mod decoder;
+pub mod encoder;
+pub mod gan;
 pub mod large_concept;
-pub mod vae;
 pub mod resnet;
 pub mod rnn;
 pub mod sequential;
 pub mod transformer;
+pub mod vae;
 
-pub use encoder::{encoder_model, EncoderLayerT, EncoderT};
-pub use decoder::{decoder_model, DecoderLayerT, DecoderT};
 pub use cnn::{simple_cnn_model, SimpleCNN};
+pub use decoder::{decoder_model, DecoderLayerT, DecoderT};
+pub use encoder::{encoder_model, EncoderLayerT, EncoderT};
+pub use gan::{Discriminator, Generator, GAN};
 pub use large_concept::{large_concept_model, LargeConceptModel};
-pub use vae::{vae_model, VAE};
 pub use resnet::{resnet_model, ResNet};
 pub use rnn::{rnn_model, RNN};
 pub use sequential::Sequential;
 pub use transformer::{TransformerEncoder, TransformerEncoderLayer};
-
+pub use vae::{vae_model, VAE};


### PR DESCRIPTION
## Summary
- introduce a minimal GAN module with Generator and Discriminator built from Linear and Conv layers
- add a training loop alternating D/G updates with `train_step`
- provide a MNIST GAN example and register module exports

## Testing
- `cargo test`
- `cargo run --example mnist_gan` *(fails: incomplete download / interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2b37220832f93e44ac5894398a8