### PR TITLE
Add Hugging Face transformer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The `examples` directory contains small programs that showcase core features of 
 
 - **Autoencoder** – `cargo run --example autoencoder`
   Runs a small variational autoencoder to reconstruct MNIST images.
+- **Hugging Face Transformer** – `cargo run --example hf_transformer`
+  Downloads a tiny BERT model and runs a dummy inference to verify tensor shapes.
 
 ## Hugging Face models
 

--- a/examples/hf_transformer.rs
+++ b/examples/hf_transformer.rs
@@ -1,0 +1,50 @@
+use std::error::Error;
+use std::fs;
+
+use vanillanoprop::huggingface;
+use vanillanoprop::math::Matrix;
+use vanillanoprop::models::TransformerEncoder;
+use vanillanoprop::weights;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Download configuration and weights for a tiny BERT model.
+    let files = huggingface::fetch_hf_files("hf-internal-testing/tiny-random-bert", None)?;
+
+    // Read dimensions from the Hugging Face configuration file.
+    #[derive(serde::Deserialize)]
+    struct HfConfig {
+        num_hidden_layers: usize,
+        hidden_size: usize,
+        num_attention_heads: usize,
+        intermediate_size: usize,
+        vocab_size: usize,
+    }
+
+    let cfg_text = fs::read_to_string(&files.config)?;
+    let cfg: HfConfig = serde_json::from_str(&cfg_text)?;
+
+    // Build a transformer using the sizes from the configuration.
+    let mut enc = TransformerEncoder::new(
+        cfg.num_hidden_layers,
+        cfg.vocab_size,
+        cfg.hidden_size,
+        cfg.num_attention_heads,
+        cfg.intermediate_size,
+        0.0,
+    );
+
+    // Load pretrained weights.
+    weights::load_transformer_from_hf(&files.config, &files.weights, &mut enc)?;
+
+    // Run a dummy inference with token ids [0, 1, 2].
+    let tokens = [0usize, 1, 2];
+    let mut x = Matrix::zeros(tokens.len(), cfg.vocab_size);
+    for (t, &id) in tokens.iter().enumerate() {
+        x.set(t, id, 1.0);
+    }
+
+    let h = enc.forward(x, None);
+    println!("Output shape: {}x{}", h.data.rows, h.data.cols);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `hf_transformer` example that builds a transformer from Hugging Face config and weights
- mention the new example in the README

## Testing
- `cargo test`
- `cargo run --example hf_transformer` *(fails: RequestError ProxyConnect)*

------
https://chatgpt.com/codex/tasks/task_e_68b128f7d630832f8e9186625c3249ae