### PR TITLE
Add optional matrixmultiply backend for matmul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,7 @@ dependencies = [
  "hf-hub",
  "indicatif",
  "libc",
+ "matrixmultiply",
  "mnist",
  "nalgebra",
  "onnx-pb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 [features]
 default = []
 kai = []
+matrixmultiply = ["dep:matrixmultiply"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -27,6 +28,7 @@ prost = "0.6"
 hf-hub = "0.4"
 ureq = "2"
 safetensors = "0.6"
+matrixmultiply = { version = "0.3", optional = true }
 
 [lib]
 name = "vanillanoprop"


### PR DESCRIPTION
## Summary
- add `matrixmultiply` crate behind a `matrixmultiply` feature
- use `matrixmultiply::sgemm` when feature is enabled
- keep existing portable Rust matmul when the feature is disabled

## Testing
- `cargo test --lib --features matrixmultiply`


------
https://chatgpt.com/codex/tasks/task_e_68b150859fd8832f87f84b27b05e0f09