### PR TITLE
docs: expand guides for advanced features

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,19 @@ Typical training commands:
 
 The `--moe` flag enables mixture-of-experts layers and `--num-experts` sets how many experts to use.
 
+### AutoML
+
+Enable random search over hyperparameters with `--auto-ml` and a config file:
+
+```bash
+./run.sh train-noprop --auto-ml --config config.toml
+```
+
+See [AutoML](docs/introduction.md#automl) for more details. ([example](docs/examples/automl.md))
+
 ### Fine-tuning
 
-Existing checkpoints from the Hugging Face Hub can be used to initialise a
-model for further training. Supply a model identifier with `--fine-tune` and
-optionally freeze layers by index via `--freeze-layers`:
+Use `--fine-tune <MODEL_ID>` to initialise from a Hugging Face checkpoint and optionally `--freeze-layers <IDX,IDX>` to keep parameters fixed:
 
 ```bash
 ./run.sh train-backprop --fine-tune bert-base-uncased --freeze-layers 0,1,2
@@ -55,6 +63,7 @@ optionally freeze layers by index via `--freeze-layers`:
 The example above downloads the `bert-base-uncased` weights, loads them into
 the Transformer and updates all parameters except the first three layers.
 
+See [Fine-tuning](docs/introduction.md#fine-tuning) for more details. ([example](docs/examples/fine_tuning.md))
 ### ONNX export
 
 Training binaries accept an optional `--export-onnx <FILE>` flag. When
@@ -62,11 +71,13 @@ provided, the trained weights are exported to an ONNX model after
 training completes. Only a small subset of layers is supported (linear
 and convolution) and the generated model targets opset 13.
 
+See [ONNX export](docs/introduction.md#onnx-export) for details on the flag. ([example](docs/examples/onnx_export.md))
+
 ## Tree Policy Optimization (TreePO)
 
 TreePO combines tree-based planning with policy optimisation to update actions using advantages estimated from a search tree. See the [Tree Policy Optimization paper](https://arxiv.org/abs/2506.03736) for details.
 
-Run a training session with a configuration file:
+Run a training session with the `train-treepo` command and a required `--config <FILE>` flag:
 
 ```bash
 ./run.sh train-treepo --config treepo_config.toml
@@ -89,6 +100,8 @@ Episode 1 complete
 Episode 2 complete
 ...
 ```
+
+See [TreePO](docs/introduction.md#treepo) for more details. ([example](docs/examples/treepo.md))
 
 ## Configuration
 
@@ -116,21 +129,21 @@ Or override specific settings from the command line:
 
 The `examples` directory contains small programs that showcase core features of the framework.
 
-- **Mixture of Experts** – `cargo run --example mixture_of_experts`
+- **Mixture of Experts** – `cargo run --example mixture_of_experts` ([walkthrough](docs/examples/mixture_of_experts.md))
   Builds a tiny mixture‑of‑experts network and prints gating probabilities.
 
-- **Loading configuration** – `cargo run --example load_config`
+- **Loading configuration** – `cargo run --example load_config` ([walkthrough](docs/examples/load_config.md))
   Loads training parameters from `lcm_config.toml` and falls back to defaults if the file is not found.
 
-- **MNIST CNN** – `cargo run --example mnist_cnn`
+- **MNIST CNN** – `cargo run --example mnist_cnn` ([walkthrough](docs/examples/mnist_cnn.md))
   Trains a simple convolutional network on the MNIST digits.
 
-- **RNN text classification** – `cargo run --example text_rnn`
+- **RNN text classification** – `cargo run --example text_rnn` ([walkthrough](docs/examples/text_rnn.md))
   Shows how to build a tiny LSTM classifier on a toy text dataset.
 
-- **Autoencoder** – `cargo run --example autoencoder`
+- **Autoencoder** – `cargo run --example autoencoder` ([walkthrough](docs/examples/autoencoder.md))
   Runs a small variational autoencoder to reconstruct MNIST images.
-- **Hugging Face Transformer** – `cargo run --example hf_transformer`
+- **Hugging Face Transformer** – `cargo run --example hf_transformer` ([walkthrough](docs/examples/hf_transformer.md))
   Downloads a tiny BERT model and runs a dummy inference to verify tensor shapes.
 
 ## Hugging Face models

--- a/docs/examples/autoencoder.md
+++ b/docs/examples/autoencoder.md
@@ -1,0 +1,11 @@
+# Autoencoder Example
+
+Demonstrates a tiny variational autoencoder that reconstructs MNIST
+images. Launch it with:
+
+```bash
+cargo run --example autoencoder
+```
+
+Weights are saved to disk after training so the model can be reused
+later.

--- a/docs/examples/automl.md
+++ b/docs/examples/automl.md
@@ -1,0 +1,11 @@
+# AutoML Example
+
+The training binaries support a simple random search over hyperparameters.
+Enable it via the `--auto-ml` flag:
+
+```bash
+./run.sh train-noprop --auto-ml --config config.toml
+```
+
+Candidate learning rates and other options are read from `config.toml`.
+The run reports the best score found during the search.

--- a/docs/examples/fine_tuning.md
+++ b/docs/examples/fine_tuning.md
@@ -1,0 +1,11 @@
+# Fine-tuning Example
+
+Initialise a model from the Hugging Face Hub and continue training while
+optionally freezing specific layers:
+
+```bash
+./run.sh train-backprop --fine-tune bert-base-uncased --freeze-layers 0,1,2
+```
+
+The command downloads the checkpoint, loads it and updates all layers
+except the first three.

--- a/docs/examples/hf_transformer.md
+++ b/docs/examples/hf_transformer.md
@@ -1,0 +1,10 @@
+# Hugging Face Transformer Example
+
+Shows how to fetch pretrained weights from the Hugging Face Hub and run a
+dummy inference. Execute:
+
+```bash
+cargo run --example hf_transformer
+```
+
+The example downloads the model and prints the resulting tensor shapes.

--- a/docs/examples/load_config.md
+++ b/docs/examples/load_config.md
@@ -1,0 +1,10 @@
+# Loading Configuration Example
+
+This example reads training parameters from a `TOML` file and falls back
+to defaults when the file is missing. Execute it with:
+
+```bash
+cargo run --example load_config
+```
+
+Review the output to see which values were loaded from `lcm_config.toml`.

--- a/docs/examples/mixture_of_experts.md
+++ b/docs/examples/mixture_of_experts.md
@@ -1,0 +1,11 @@
+# Mixture of Experts Example
+
+This walkthrough builds a tiny mixture-of-experts layer and prints the
+routing probabilities for each input. Run it with cargo:
+
+```bash
+cargo run --example mixture_of_experts
+```
+
+The source code demonstrates how to construct experts and combine them
+with the `MixtureOfExpertsT` layer.

--- a/docs/examples/mnist_cnn.md
+++ b/docs/examples/mnist_cnn.md
@@ -1,0 +1,10 @@
+# MNIST CNN Example
+
+Trains a small convolutional network on the MNIST digits dataset. Run:
+
+```bash
+cargo run --example mnist_cnn
+```
+
+The program prints the loss after each batch, giving a quick signal of
+training progress.

--- a/docs/examples/onnx_export.md
+++ b/docs/examples/onnx_export.md
@@ -1,0 +1,10 @@
+# ONNX Export Example
+
+Training binaries can export weights to the ONNX format by providing an
+output path:
+
+```bash
+./run.sh train-noprop --export-onnx model.onnx
+```
+
+Only a subset of layers is supported. The resulting model targets opset 13.

--- a/docs/examples/text_rnn.md
+++ b/docs/examples/text_rnn.md
@@ -1,0 +1,11 @@
+# Text RNN Example
+
+This walkthrough builds a simple LSTM for toy text classification. Invoke
+it with:
+
+```bash
+cargo run --example text_rnn
+```
+
+Inspect the source to see how inputs are encoded and passed through the
+network.

--- a/docs/examples/treepo.md
+++ b/docs/examples/treepo.md
@@ -1,0 +1,11 @@
+# TreePO Example
+
+Tree Policy Optimisation (TreePO) combines planning with policy
+optimisation. Start a training run with:
+
+```bash
+./run.sh train-treepo --config treepo_config.toml
+```
+
+The configuration file sets hyperparameters such as `gamma`, `lam` and
+`max_depth`.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -66,3 +66,60 @@ if let Err(e) = save_vae("vae.json", &vae) {
 
 Persisting models allows you to reload them later for inference or continued training.
 
+
+## AutoML
+
+```rust
+// src/bin/train_noprop.rs
+if auto_ml {
+    use vanillanoprop::automl::{random_search, SearchSpace};
+    let space = SearchSpace::from_config(&config);
+    let eval = |_cfg: Config| rand::random::<f32>();
+    let (_best_cfg, best_score) = random_search(&space, 10, eval, &mut rng, &mut logger);
+    println!("AutoML best score: {best_score:.4}");
+    return;
+}
+```
+
+Enable random search with `./run.sh train-noprop --auto-ml --config config.toml`.
+See the [AutoML example](examples/automl.md) for a full walkthrough.
+
+## Fine-tuning
+
+```rust
+// src/bin/train_noprop.rs
+let _ft = fine_tune.map(|model_id| {
+    vanillanoprop::fine_tune::run(&model_id, freeze_layers, |_, _| Ok(()))
+        .expect("fine-tune load failed")
+});
+```
+
+Initialise from a Hugging Face checkpoint using
+`./run.sh train-backprop --fine-tune bert-base-uncased`.
+Further details in the [fine-tuning example](examples/fine_tuning.md).
+
+## ONNX export
+
+```rust
+// src/bin/common.rs
+"--export-onnx" => {
+    if let Some(v) = args.next() {
+        export_onnx = Some(v);
+    }
+}
+```
+
+Training binaries accept `--export-onnx <FILE>` to write weights in the
+ONNX format. Check the [ONNX export example](examples/onnx_export.md).
+
+## TreePO
+
+```rust
+// src/rl/treepo.rs
+pub fn update_policy(/* ... */) {
+    // Tree-based policy optimisation
+}
+```
+
+Launch a TreePO run with `./run.sh train-treepo --config treepo_config.toml`.
+See the [TreePO example](examples/treepo.md) for configuration details.


### PR DESCRIPTION
## Summary
- document AutoML, fine-tuning, ONNX export, and TreePO in the introduction
- cross-link README to new docs and add walkthroughs for each example
- add detailed example guides under `docs/examples`

## Testing
- `cargo test` *(fails: test `hf_loading`)*

------
https://chatgpt.com/codex/tasks/task_e_68b17c9b2fcc832fa118e1ce5150fda0