### PR TITLE
ci: add lint and fmt checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Format
+      run: cargo fmt --all --check
+    - name: Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
## Summary
- run cargo fmt and clippy in CI before building

## Testing
- `cargo fmt --all --check` *(fails: formatting differences)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: 107 errors)*
- `cargo test` *(fails: test hf_loading)*

------
https://chatgpt.com/codex/tasks/task_e_68b187907240832fab70074e414097cf