### PR TITLE
feat: support freezing different layer types

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -1,5 +1,6 @@
 use std::env;
 use vanillanoprop::config::Config;
+use vanillanoprop::fine_tune::FreezeSpec;
 use vanillanoprop::optim::lr_scheduler::LrScheduleConfig;
 
 /// Parses common CLI arguments across training binaries.
@@ -40,7 +41,7 @@ pub fn parse_cli<I>(
     Option<String>,
     Option<String>,
     Option<String>,
-    Vec<usize>,
+    Vec<FreezeSpec>,
     bool,
     Config,
     Vec<String>,
@@ -63,7 +64,7 @@ where
     let mut experiment_name = None;
     let mut export_onnx = None;
     let mut fine_tune = None;
-    let mut freeze_layers = Vec::new();
+    let mut freeze_layers: Vec<FreezeSpec> = Vec::new();
     let mut auto_ml = false;
     let mut epochs = None;
     let mut batch_size = None;
@@ -267,7 +268,7 @@ pub fn parse_env() -> (
     Option<String>,
     Option<String>,
     Option<String>,
-    Vec<usize>,
+    Vec<FreezeSpec>,
     bool,
     Config,
     Vec<String>,

--- a/src/fine_tune.rs
+++ b/src/fine_tune.rs
@@ -1,7 +1,26 @@
 use crate::huggingface::fetch_hf_files;
 use crate::layers::LinearT;
+use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;
+
+/// Kinds of layers that expose trainable [`LinearT`] parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LayerKind {
+    /// Fully connected / linear layers.
+    Linear,
+    /// Convolution layers.
+    Conv,
+}
+
+/// Specification of a layer that should remain frozen during optimisation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FreezeSpec {
+    /// The type of layer (e.g. linear, convolution).
+    pub kind: LayerKind,
+    /// Index of the parameter within the group of the specified `kind`.
+    pub idx: usize,
+}
 
 /// Representation of a fine-tuning session.
 ///
@@ -10,23 +29,41 @@ use std::path::Path;
 /// obtain only the unfrozen parameters for an update step.
 #[derive(Debug, Clone)]
 pub struct FineTune {
-    frozen: Vec<usize>,
+    frozen: Vec<FreezeSpec>,
 }
 
 impl FineTune {
-    /// Create a new [`FineTune`] configuration with the provided frozen layer
-    /// indices.
-    pub fn new(frozen: Vec<usize>) -> Self {
+    /// Create a new [`FineTune`] configuration with the provided frozen
+    /// specifications.
+    pub fn new(frozen: Vec<FreezeSpec>) -> Self {
         Self { frozen }
     }
 
     /// Filter the provided parameters, returning only those that are not
     /// frozen.
-    pub fn filter<'a>(&self, params: Vec<&'a mut LinearT>) -> Vec<&'a mut LinearT> {
+    ///
+    /// The `params` vector should contain tuples of the layer kind and a
+    /// mutable reference to the underlying [`LinearT`] parameters. Indices are
+    /// tracked per layer kind, allowing heterogeneous parameter lists to be
+    /// filtered correctly.
+    pub fn filter<'a>(&self, params: Vec<(LayerKind, &'a mut LinearT)>) -> Vec<&'a mut LinearT> {
+        let mut counts: HashMap<LayerKind, usize> = HashMap::new();
         params
             .into_iter()
-            .enumerate()
-            .filter_map(|(i, p)| if self.frozen.contains(&i) { None } else { Some(p) })
+            .filter_map(|(kind, p)| {
+                let idx = counts.entry(kind).or_insert(0);
+                let current = *idx;
+                *idx += 1;
+                if self
+                    .frozen
+                    .iter()
+                    .any(|f| f.kind == kind && f.idx == current)
+                {
+                    None
+                } else {
+                    Some(p)
+                }
+            })
             .collect()
     }
 }
@@ -44,7 +81,7 @@ impl FineTune {
 /// to optimisation steps.
 pub fn run<F>(
     model_id: &str,
-    freeze_layers: Vec<usize>,
+    freeze_layers: Vec<FreezeSpec>,
     mut load_fn: F,
 ) -> Result<FineTune, Box<dyn Error>>
 where
@@ -55,10 +92,20 @@ where
     Ok(FineTune::new(freeze_layers))
 }
 
-/// Convenience helper to parse a comma separated list of layer indices into a
-/// vector.
-pub fn parse_freeze_list(list: &str) -> Vec<usize> {
+/// Convenience helper to parse a comma separated list of layer specifications
+/// into a vector. Each entry should be of the form `"<kind>:<index>"`, e.g.
+/// `"linear:0,conv:1"`.
+pub fn parse_freeze_list(list: &str) -> Vec<FreezeSpec> {
     list.split(',')
-        .filter_map(|s| s.trim().parse::<usize>().ok())
+        .filter_map(|s| {
+            let mut parts = s.split(':');
+            let kind = match parts.next()?.trim().to_lowercase().as_str() {
+                "linear" => LayerKind::Linear,
+                "conv" | "conv2d" => LayerKind::Conv,
+                _ => return None,
+            };
+            let idx = parts.next()?.trim().parse::<usize>().ok()?;
+            Some(FreezeSpec { kind, idx })
+        })
         .collect()
 }

--- a/tests/fine_tune.rs
+++ b/tests/fine_tune.rs
@@ -1,0 +1,48 @@
+use vanillanoprop::fine_tune::{FineTune, FreezeSpec, LayerKind};
+use vanillanoprop::layers::{Conv2d, LinearT};
+
+#[test]
+fn freeze_linear_layer() {
+    let mut lin = LinearT::new(2, 2);
+    let params = vec![(LayerKind::Linear, &mut lin)];
+    let ft = FineTune::new(vec![FreezeSpec {
+        kind: LayerKind::Linear,
+        idx: 0,
+    }]);
+    let filtered = ft.filter(params);
+    assert!(filtered.is_empty());
+}
+
+#[test]
+fn freeze_conv_layer() {
+    let mut conv = Conv2d::new(1, 1, 1, 1, 0);
+    let params: Vec<(LayerKind, &mut LinearT)> = conv
+        .parameters()
+        .into_iter()
+        .map(|p| (LayerKind::Conv, p))
+        .collect();
+    let ft = FineTune::new(vec![FreezeSpec {
+        kind: LayerKind::Conv,
+        idx: 0,
+    }]);
+    let filtered = ft.filter(params);
+    assert!(filtered.is_empty());
+}
+
+#[test]
+fn mixed_layers_freeze_conv() {
+    let mut conv = Conv2d::new(1, 1, 1, 1, 0);
+    let mut lin = LinearT::new(1, 1);
+    let mut params: Vec<(LayerKind, &mut LinearT)> = conv
+        .parameters()
+        .into_iter()
+        .map(|p| (LayerKind::Conv, p))
+        .collect();
+    params.push((LayerKind::Linear, &mut lin));
+    let ft = FineTune::new(vec![FreezeSpec {
+        kind: LayerKind::Conv,
+        idx: 0,
+    }]);
+    let filtered = ft.filter(params);
+    assert_eq!(filtered.len(), 1);
+}


### PR DESCRIPTION
## Summary
- generalize fine-tuning filter with `LayerKind` and `FreezeSpec`
- parse `--freeze-layers` as typed layer specs
- adapt training binaries to handle heterogeneous parameter lists
- add tests for freezing linear and convolution layers

## Testing
- `cargo test` *(fails: failed to fetch model weights: RequestError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1913be19c832f960e0af6d824899c