### PR TITLE
Add ONNX export support for ReLU, pooling and batch norm

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ See [Fine-tuning](docs/introduction.md#fine-tuning) for more details. ([example]
 
 Training binaries accept an optional `--export-onnx <FILE>` flag. When
 provided, the trained weights are exported to an ONNX model after
-training completes. Only a small subset of layers is supported (linear
-and convolution) and the generated model targets opset 13.
+training completes. Supported layers include linear, convolution,
+ReLU, max pooling and batch normalization. The generated model targets
+opset 13.
 
 See [ONNX export](docs/introduction.md#onnx-export) for details on the flag. ([example](docs/examples/onnx_export.md))
 

--- a/docs/examples/onnx_export.md
+++ b/docs/examples/onnx_export.md
@@ -7,4 +7,5 @@ output path:
 ./run.sh train-noprop --export-onnx model.onnx
 ```
 
-Only a subset of layers is supported. The resulting model targets opset 13.
+The exporter supports linear, convolution, ReLU, max pooling and batch
+normalization layers. The resulting model targets opset 13.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -110,7 +110,9 @@ Further details in the [fine-tuning example](examples/fine_tuning.md).
 ```
 
 Training binaries accept `--export-onnx <FILE>` to write weights in the
-ONNX format. Check the [ONNX export example](examples/onnx_export.md).
+ONNX format. The exporter currently handles linear, convolution, ReLU,
+max pooling and batch normalization layers. Check the
+[ONNX export example](examples/onnx_export.md).
 
 ## TreePO
 

--- a/src/export/onnx.rs
+++ b/src/export/onnx.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::error::Error;
 use std::path::Path;
 
-use crate::layers::{Conv2d, LinearT};
+use crate::layers::{BatchNorm, Conv2d, LinearT, MaxPool2d, ReLUT};
 use crate::models::Sequential;
 
 use onnx_pb::{
@@ -40,6 +40,12 @@ pub fn export_to_onnx(model: &Sequential, path: &Path) -> Result<(), Box<dyn Err
             add_linear(linear, &prev_out, &out_name, &mut graph);
         } else if let Some(conv) = any.downcast_ref::<Conv2d>() {
             add_conv(conv, &prev_out, &out_name, &mut graph);
+        } else if any.is::<ReLUT>() {
+            add_relu(&prev_out, &out_name, &mut graph);
+        } else if let Some(pool) = any.downcast_ref::<MaxPool2d>() {
+            add_max_pool(pool, &prev_out, &out_name, &mut graph);
+        } else if let Some(bn) = any.downcast_ref::<BatchNorm>() {
+            add_batch_norm(bn, &prev_out, &out_name, &mut graph);
         } else {
             // Unsupported layer – insert identity node
             graph.node.push(NodeProto {
@@ -130,6 +136,101 @@ fn add_conv(layer: &Conv2d, input: &str, output: &str, graph: &mut GraphProto) {
             layer.padding() as i64,
             layer.padding() as i64,
         ],
+        ..Default::default()
+    });
+    graph.node.push(node);
+}
+
+fn add_relu(input: &str, output: &str, graph: &mut GraphProto) {
+    graph.node.push(NodeProto {
+        op_type: "Relu".into(),
+        input: vec![input.into()],
+        output: vec![output.into()],
+        ..Default::default()
+    });
+}
+
+fn add_max_pool(layer: &MaxPool2d, input: &str, output: &str, graph: &mut GraphProto) {
+    let mut node = NodeProto {
+        op_type: "MaxPool".into(),
+        input: vec![input.into()],
+        output: vec![output.into()],
+        attribute: Vec::new(),
+        ..Default::default()
+    };
+    node.attribute.push(AttributeProto {
+        name: "kernel_shape".into(),
+        r#type: AttributeType::Ints as i32,
+        ints: vec![layer.kernel() as i64, layer.kernel() as i64],
+        ..Default::default()
+    });
+    node.attribute.push(AttributeProto {
+        name: "strides".into(),
+        r#type: AttributeType::Ints as i32,
+        ints: vec![layer.stride() as i64, layer.stride() as i64],
+        ..Default::default()
+    });
+    graph.node.push(node);
+}
+
+fn add_batch_norm(layer: &BatchNorm, input: &str, output: &str, graph: &mut GraphProto) {
+    let scale_name = format!("{}__scale", output);
+    let scale = TensorProto {
+        name: scale_name.clone(),
+        data_type: DataType::Float as i32,
+        dims: vec![layer.gamma.w.len() as i64],
+        float_data: layer.gamma.w.clone(),
+        ..Default::default()
+    };
+    graph.initializer.push(scale);
+
+    let bias_name = format!("{}__bias", output);
+    let bias = TensorProto {
+        name: bias_name.clone(),
+        data_type: DataType::Float as i32,
+        dims: vec![layer.beta.w.len() as i64],
+        float_data: layer.beta.w.clone(),
+        ..Default::default()
+    };
+    graph.initializer.push(bias);
+
+    let mean_name = format!("{}__mean", output);
+    let mean = TensorProto {
+        name: mean_name.clone(),
+        data_type: DataType::Float as i32,
+        dims: vec![layer.running_mean().len() as i64],
+        float_data: layer.running_mean().to_vec(),
+        ..Default::default()
+    };
+    graph.initializer.push(mean);
+
+    let var_name = format!("{}__var", output);
+    let var = TensorProto {
+        name: var_name.clone(),
+        data_type: DataType::Float as i32,
+        dims: vec![layer.running_var().len() as i64],
+        float_data: layer.running_var().to_vec(),
+        ..Default::default()
+    };
+    graph.initializer.push(var);
+
+    let mut node = NodeProto {
+        op_type: "BatchNormalization".into(),
+        input: vec![
+            input.into(),
+            scale_name,
+            bias_name,
+            mean_name,
+            var_name,
+        ],
+        output: vec![output.into()],
+        attribute: Vec::new(),
+        ..Default::default()
+    };
+    node.attribute.push(AttributeProto {
+        name: "epsilon".into(),
+        r#type: AttributeType::Float as i32,
+        f: layer.eps(),
         ..Default::default()
     });
     graph.node.push(node);

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -24,6 +24,13 @@ pub use linear::LinearT;
 pub use mixture_of_experts::MixtureOfExpertsT;
 pub use multi_head_attention::MultiHeadAttentionT;
 pub use normalization::{BatchNorm, LayerNorm};
-pub use pooling::{avg_pool2d, avg_pool2d_backward, max_pool2d, max_pool2d_backward};
+pub use pooling::{
+    avg_pool2d,
+    avg_pool2d_backward,
+    max_pool2d,
+    max_pool2d_backward,
+    MaxPool2d,
+};
 pub use rnn::{GRU, LSTM};
+pub use relu::ReLUT;
 pub use softmax::SoftmaxT;

--- a/src/layers/normalization.rs
+++ b/src/layers/normalization.rs
@@ -83,6 +83,21 @@ impl BatchNorm {
         }
     }
 
+    /// Running mean used during inference.
+    pub fn running_mean(&self) -> &[f32] {
+        &self.running_mean
+    }
+
+    /// Running variance used during inference.
+    pub fn running_var(&self) -> &[f32] {
+        &self.running_var
+    }
+
+    /// Epsilon constant for numerical stability.
+    pub fn eps(&self) -> f32 {
+        self.eps
+    }
+
     pub fn forward(&self, x: &Tensor) -> Tensor {
         let rows = x.data.rows;
         let cols = x.data.cols;

--- a/src/layers/pooling.rs
+++ b/src/layers/pooling.rs
@@ -1,4 +1,7 @@
 use crate::math::Matrix;
+use crate::tensor::Tensor;
+use super::layer::Layer;
+use super::linear::LinearT;
 
 /// 2D max pooling forward pass.
 ///
@@ -107,4 +110,91 @@ pub fn avg_pool2d_backward(
         }
     }
     grad_input
+}
+
+/// Max pooling layer implementing the [`Layer`] trait.
+pub struct MaxPool2d {
+    kernel: usize,
+    stride: usize,
+    indices: Vec<usize>,
+    input_rows: usize,
+    input_cols: usize,
+}
+
+impl MaxPool2d {
+    /// Create a new max pooling layer.
+    pub fn new(kernel: usize, stride: usize) -> Self {
+        Self {
+            kernel,
+            stride,
+            indices: Vec::new(),
+            input_rows: 0,
+            input_cols: 0,
+        }
+    }
+
+    /// Access the kernel size.
+    pub fn kernel(&self) -> usize {
+        self.kernel
+    }
+
+    /// Access the stride.
+    pub fn stride(&self) -> usize {
+        self.stride
+    }
+
+    fn forward_internal(&self, x: &Tensor) -> Tensor {
+        let (out, _idx) = max_pool2d(&x.data, self.kernel, self.stride);
+        Tensor::from_matrix(out)
+    }
+
+    fn forward_train_internal(&mut self, x: &Matrix) -> Matrix {
+        self.input_rows = x.rows;
+        self.input_cols = x.cols;
+        let (out, idx) = max_pool2d(x, self.kernel, self.stride);
+        self.indices = idx;
+        out
+    }
+
+    fn backward_internal(&self, grad_out: &Matrix) -> Matrix {
+        max_pool2d_backward(
+            grad_out,
+            &self.indices,
+            self.input_rows,
+            self.input_cols,
+        )
+    }
+}
+
+impl Layer for MaxPool2d {
+    fn forward(&self, x: &Tensor) -> Tensor {
+        self.forward_internal(x)
+    }
+
+    fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        self.forward_train_internal(x)
+    }
+
+    fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        self.backward_internal(grad_out)
+    }
+
+    fn zero_grad(&mut self) {}
+
+    fn fa_update(&mut self, grad_out: &Matrix, _lr: f32) -> Matrix {
+        self.backward_internal(grad_out)
+    }
+
+    fn adam_step(
+        &mut self,
+        _lr: f32,
+        _beta1: f32,
+        _beta2: f32,
+        _eps: f32,
+        _weight_decay: f32,
+    ) {}
+
+    fn parameters(&mut self) -> Vec<&mut LinearT> {
+        Vec::new()
+    }
 }

--- a/src/layers/relu.rs
+++ b/src/layers/relu.rs
@@ -1,5 +1,7 @@
 use crate::math::Matrix;
 use crate::tensor::Tensor;
+use super::layer::Layer;
+use super::linear::LinearT;
 
 /// Apply ReLU activation in place on a tensor.
 pub fn forward_tensor(t: &mut Tensor) {
@@ -27,6 +29,69 @@ pub fn forward_matrix(m: &mut Matrix) -> Vec<f32> {
 pub fn backward(grad: &mut Matrix, mask: &[f32]) {
     for (g, &m) in grad.data.iter_mut().zip(mask.iter()) {
         *g *= m;
+    }
+}
+
+/// ReLU activation layer implementing the [`Layer`] trait.
+pub struct ReLUT {
+    mask: Vec<f32>,
+}
+
+impl ReLUT {
+    /// Create a new ReLU layer.
+    pub fn new() -> Self {
+        Self { mask: Vec::new() }
+    }
+
+    fn forward_internal(x: &Tensor) -> Tensor {
+        let mut out = x.clone();
+        forward_tensor(&mut out);
+        out
+    }
+
+    fn forward_train_internal(&mut self, x: &Matrix) -> Matrix {
+        let mut out = x.clone();
+        self.mask = forward_matrix(&mut out);
+        out
+    }
+
+    fn backward_internal(&self, grad_out: &Matrix) -> Matrix {
+        let mut grad = grad_out.clone();
+        backward(&mut grad, &self.mask);
+        grad
+    }
+}
+
+impl Layer for ReLUT {
+    fn forward(&self, x: &Tensor) -> Tensor {
+        Self::forward_internal(x)
+    }
+
+    fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        self.forward_train_internal(x)
+    }
+
+    fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        self.backward_internal(grad_out)
+    }
+
+    fn zero_grad(&mut self) {}
+
+    fn fa_update(&mut self, grad_out: &Matrix, _lr: f32) -> Matrix {
+        self.backward_internal(grad_out)
+    }
+
+    fn adam_step(
+        &mut self,
+        _lr: f32,
+        _beta1: f32,
+        _beta2: f32,
+        _eps: f32,
+        _weight_decay: f32,
+    ) {}
+
+    fn parameters(&mut self) -> Vec<&mut LinearT> {
+        Vec::new()
     }
 }
 

--- a/tests/onnx_layers.rs
+++ b/tests/onnx_layers.rs
@@ -1,0 +1,22 @@
+use vanillanoprop::export::onnx::export_to_onnx;
+use vanillanoprop::layers::{BatchNorm, MaxPool2d, ReLUT};
+use vanillanoprop::models::Sequential;
+use onnx_pb::ModelProto;
+use prost::Message;
+
+#[test]
+fn export_includes_common_layers() {
+    let mut model = Sequential::new();
+    model.add_layer(Box::new(ReLUT::new()));
+    model.add_layer(Box::new(MaxPool2d::new(2, 2)));
+    model.add_layer(Box::new(BatchNorm::new(1, 1e-5, 0.9)));
+
+    let path = std::env::temp_dir().join("onnx_test_model.onnx");
+    export_to_onnx(&model, &path).expect("export failed");
+    let data = std::fs::read(&path).expect("read onnx");
+    let proto = ModelProto::decode(&*data).expect("decode onnx");
+    let graph = proto.graph.expect("graph");
+    let ops: Vec<_> = graph.node.iter().map(|n| n.op_type.as_str()).collect();
+    assert_eq!(ops, vec!["Relu", "MaxPool", "BatchNormalization"]);
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
## Summary
- extend ONNX exporter with ReLU, MaxPool and BatchNormalization nodes
- expose running statistics from BatchNorm and add ReLU/MaxPool2d layers
- document and test support for new exported layers

## Testing
- `cargo test --test onnx_layers`
- `cargo test` *(fails: failed to fetch model weights: RequestError(Transport(ProxyConnect))*

------
https://chatgpt.com/codex/tasks/task_e_68b1972fbf54832fa85d65605d16b475