### PR TITLE
Add TreePO policy update with learning rate and tests

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -118,10 +118,13 @@ max pooling and batch normalization layers. Check the
 
 ```rust
 // src/rl/treepo.rs
-pub fn update_policy(/* ... */) {
-    // Tree-based policy optimisation
+pub fn update_policy(&mut self) {
+    // Backpropagate advantages and update policy with learning rate `lr`
 }
 ```
+
+`TreePoAgent::new` expects an additional `lr` parameter controlling the step
+size of the policy update.
 
 Launch a TreePO run with `./run.sh train-treepo --config treepo_config.toml`.
 See the [TreePO example](examples/treepo.md) for configuration details.

--- a/examples/treepo.rs
+++ b/examples/treepo.rs
@@ -52,7 +52,7 @@ fn main() {
         position: 0,
         goal: 5,
     };
-    let mut agent = TreePoAgent::new(env, 0.9, 0.95, 10, 10);
+    let mut agent = TreePoAgent::new(env, 0.9, 0.95, 10, 10, 0.1);
 
     // Actions available to the agent: move left or right
     let actions = [-1, 1];
@@ -66,6 +66,7 @@ fn main() {
             state,
             value: 0.0,
             visits: 0,
+            policy: 1.0,
             children: HashMap::new(),
         };
 
@@ -92,7 +93,7 @@ fn main() {
         }
 
         // Inspect the learned probability of moving right from the root
-        let p_right = agent.root.children.get(&1).map(|c| c.value).unwrap_or(0.0);
+        let p_right = agent.root.children.get(&1).map(|c| c.policy).unwrap_or(0.0);
         println!("Episode {}: P(move right)={:.2}", episode + 1, p_right);
     }
 }

--- a/src/bin/train_treepo.rs
+++ b/src/bin/train_treepo.rs
@@ -36,7 +36,7 @@ fn main() {
         position: 0,
         goal: 5,
     };
-    let mut agent = TreePoAgent::new(env, 0.9, 0.95, 10, 10);
+    let mut agent = TreePoAgent::new(env, 0.9, 0.95, 10, 10, 0.1);
     let actions = [-1, 1];
     let mut rng = rand::thread_rng();
     let episodes = 10;
@@ -56,6 +56,7 @@ fn main() {
                     state: next_state,
                     value: 0.0,
                     visits: 0,
+                    policy: 0.0,
                     children: HashMap::new(),
                 });
                 TreePoAgent::<LineWorld>::backup(child, reward);

--- a/tests/treepo.rs
+++ b/tests/treepo.rs
@@ -38,7 +38,7 @@ impl Env for TwoStateEnv {
 #[test]
 fn tree_expansion_selects_optimal_action() {
     let env = TwoStateEnv::new();
-    let mut agent = TreePoAgent::new(env, 1.0, 1.0, 1, 1);
+    let mut agent = TreePoAgent::new(env, 1.0, 1.0, 1, 1, 1.0);
 
     // Expand both actions from the root and backup their rewards.
     agent.env.reset();
@@ -73,7 +73,7 @@ fn tree_expansion_selects_optimal_action() {
 #[test]
 fn policy_update_improves_over_random() {
     let env = TwoStateEnv::new();
-    let mut agent = TreePoAgent::new(env, 1.0, 1.0, 1, 1);
+    let mut agent = TreePoAgent::new(env, 1.0, 1.0, 1, 1, 1.0);
 
     // Collect data for both actions.
     agent.env.reset();
@@ -96,14 +96,14 @@ fn policy_update_improves_over_random() {
         .children
         .get(&0)
         .expect("child node for action 0 missing")
-        .value;
+        .policy;
     let expected_return: f32 = agent
         .root
         .children
         .iter()
         .map(|(a, child)| {
             let reward = if *a == 0 { 1.0 } else { 0.0 };
-            child.value * reward
+            child.policy * reward
         })
         .sum();
 
@@ -113,4 +113,88 @@ fn policy_update_improves_over_random() {
         expected_return > 0.5,
         "policy update should improve expected return"
     );
+}
+
+#[derive(Clone)]
+struct TwoStepEnv {
+    state: i32,
+}
+
+impl TwoStepEnv {
+    fn new() -> Self {
+        Self { state: 0 }
+    }
+}
+
+impl Env for TwoStepEnv {
+    type State = i32;
+    type Action = i32;
+
+    fn reset(&mut self) -> Self::State {
+        self.state = 0;
+        self.state
+    }
+
+    fn step(&mut self, action: Self::Action) -> (Self::State, f32) {
+        match self.state {
+            0 => {
+                if action == 0 {
+                    self.state = 2;
+                    (self.state, 1.0)
+                } else {
+                    self.state = 1;
+                    (self.state, 0.0)
+                }
+            }
+            1 => {
+                self.state = 2;
+                (self.state, 2.0)
+            }
+            _ => (self.state, 0.0),
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        self.state == 2
+    }
+}
+
+#[test]
+fn policy_update_backpropagates_advantage() {
+    let env = TwoStepEnv::new();
+    let mut agent = TreePoAgent::new(env, 1.0, 1.0, 2, 2, 1.0);
+
+    // Expand immediate reward branch.
+    agent.env.reset();
+    let (next0, r0) = agent.env.step(0);
+    let mut root = agent.root.clone();
+    let child0 = agent.expand_node(&mut root, 0, next0);
+    TreePoAgent::<TwoStepEnv>::backup(child0, r0);
+
+    // Expand delayed reward branch.
+    agent.env.reset();
+    let (mid, _) = agent.env.step(1);
+    let child1 = agent.expand_node(&mut root, 1, mid);
+    // From mid state take any action to receive reward.
+    let (terminal, r2) = agent.env.step(0);
+    let grand_child = agent.expand_node(child1, 0, terminal);
+    TreePoAgent::<TwoStepEnv>::backup(grand_child, r2);
+    agent.root = root;
+
+    agent.update_policy();
+
+    let p0 = agent
+        .root
+        .children
+        .get(&0)
+        .expect("child for action 0 missing")
+        .policy;
+    let p1 = agent
+        .root
+        .children
+        .get(&1)
+        .expect("child for action 1 missing")
+        .policy;
+
+    assert!(p1 > p0, "policy should favour delayed higher reward");
 }

--- a/treepo_config.toml
+++ b/treepo_config.toml
@@ -2,4 +2,5 @@ gamma = 0.99
 lam = 0.95
 max_depth = 10
 rollout_steps = 10
+learning_rate = 0.1
 episodes = 10


### PR DESCRIPTION
## Summary
- implement advantage backpropagation and gradient-based policy update for TreePO
- expose learning-rate parameter and update docs
- test TreePO policy improvement and advantage propagation

## Testing
- `cargo test --test treepo -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b19d8408c4832f90a4f1a6d8f9da32