### PR TITLE
Add MoE support for LCM, RNN and CNN predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Typical training commands:
 
 The `--moe` flag enables mixture-of-experts layers and `--num-experts` sets how many experts to use.
 
+When predicting with `--moe`, a corresponding `moe.json` file is read to load the gating and expert weights.
+
 ### AutoML
 
 Enable random search over hyperparameters with `--auto-ml` and a config file:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -16,6 +16,14 @@ let mut moe = MixtureOfExpertsT::new(4, experts, 1);
 
 The gating mechanism selects which expert should process each input, enabling sparse routing and efficient scaling.
 
+Weights for a mixture-of-experts layer can be persisted and later reloaded:
+
+```rust
+use vanillanoprop::weights::{save_moe, load_moe};
+save_moe("moe.json", &mut moe)?;
+let restored = load_moe("moe.json", 4, 8, 3)?;
+```
+
 ## Training
 
 The following snippet trains a recurrent neural network for text classification:

--- a/examples/mnist_cnn.rs
+++ b/examples/mnist_cnn.rs
@@ -2,11 +2,12 @@ use vanillanoprop::data::{Dataset, Mnist};
 use vanillanoprop::layers::{Layer, LinearT, MixtureOfExpertsT};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::models::SimpleCNN;
+use vanillanoprop::weights::save_moe;
 
 fn main() {
     // Load MNIST and group into mini-batches using the Dataset API.
     let batches = Mnist::batch(32);
-    let mut cnn = SimpleCNN::new(10);
+    let cnn = SimpleCNN::new(10);
     let lr = 0.01f32;
     let experts: Vec<Box<dyn Layer>> = (0..3)
         .map(|_| Box::new(LinearT::new(28 * 28, 10)) as Box<dyn Layer>)
@@ -29,5 +30,9 @@ fn main() {
             }
         }
         println!("batch {i} loss {}", loss_sum / batch.len() as f32);
+    }
+
+    if let Err(e) = save_moe("moe.json", &mut moe) {
+        eprintln!("failed to save MoE weights: {e}");
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -16,7 +16,7 @@ pub use encoder::{encoder_model, EncoderLayerT, EncoderT};
 pub use gan::{Discriminator, Generator, GAN};
 pub use large_concept::{large_concept_model, LargeConceptModel};
 pub use resnet::{resnet_model, ResNet};
-pub use rnn::{rnn_model, RNN};
+pub use rnn::{rnn_model, RnnCell, RNN};
 pub use sequential::Sequential;
 pub use transformer::{TransformerEncoder, TransformerEncoderLayer};
 pub use vae::{vae_model, VAE};


### PR DESCRIPTION
## Summary
- Load and run mixture-of-experts layers for LCM, RNN and CNN predictions
- Add JSON serialization helpers for MoE layers and update example and docs
- Export `RnnCell` in model module

## Testing
- `cargo test` *(fails: failed to fetch model weights: RequestError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a8e1bf5c832fa4169f15d805c572