### PR TITLE
Introduce basic tensor structure with broadcasting

### DIFF
--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -1,40 +1,151 @@
-use crate::math::{self, Matrix};
+use crate::math;
+use crate::math::Matrix;
 
-#[derive(Clone)]
+/// N-dimensional tensor backed by a flat `Vec<f32>`.
+///
+/// The tensor stores its shape explicitly allowing operations on
+/// higher-rank data.  Many legacy parts of the codebase still operate on
+/// the 2-D [`Matrix`] type, so conversion helpers are provided to ease the
+/// transition.
+#[derive(Clone, Debug, PartialEq)]
 pub struct Tensor {
-    pub data: Matrix,
+    /// Tensor elements in row-major order.
+    pub data: Vec<f32>,
+    /// Sizes for each dimension.
+    pub shape: Vec<usize>,
 }
 
 impl Tensor {
-    pub fn from_matrix(data: Matrix) -> Self {
-        Tensor { data }
+    /// Create a new tensor from raw parts.  The number of elements in `data`
+    /// must match the product of the requested `shape`.
+    pub fn new(data: Vec<f32>, shape: Vec<usize>) -> Self {
+        assert_eq!(data.len(), shape.iter().product());
+        Tensor { data, shape }
     }
 
+    /// Convenience constructor taking ownership of a [`Matrix`] while
+    /// recording its two dimensional shape.  This is primarily used while
+    /// refactoring existing code that still produces matrices.
+    pub fn from_matrix(m: Matrix) -> Self {
+        Tensor {
+            shape: vec![m.rows, m.cols],
+            data: m.data,
+        }
+    }
+
+    /// Compute the flat index for a multi-dimensional coordinate.
+    fn offset(&self, idx: &[usize]) -> usize {
+        assert_eq!(idx.len(), self.shape.len());
+        let mut stride = 1;
+        let mut off = 0usize;
+        for (i, &dim) in self.shape.iter().rev().enumerate() {
+            let id = idx[self.shape.len() - 1 - i];
+            assert!(id < dim, "index out of bounds");
+            off += id * stride;
+            stride *= dim;
+        }
+        off
+    }
+
+    /// Basic immutable indexing.
+    pub fn get(&self, idx: &[usize]) -> f32 {
+        let off = self.offset(idx);
+        self.data[off]
+    }
+
+    /// Mutable indexing support.
+    pub fn set(&mut self, idx: &[usize], value: f32) {
+        let off = self.offset(idx);
+        self.data[off] = value;
+    }
+
+    /// Change the view of the underlying data without modifying order.
+    /// The new shape must contain the same number of elements.
+    pub fn reshape(&mut self, new_shape: Vec<usize>) {
+        assert_eq!(self.data.len(), new_shape.iter().product());
+        self.shape = new_shape;
+    }
+
+    /// Broadcast the tensor to a larger shape following numpy semantics
+    /// where dimensions of size 1 can be expanded.
+    pub fn broadcast_to(&self, target: &[usize]) -> Tensor {
+        assert!(target.len() >= self.shape.len());
+        for (&src, &dst) in self.shape.iter().rev().zip(target.iter().rev()) {
+            assert!(src == dst || src == 1, "cannot broadcast dimension");
+        }
+
+        let out_len: usize = target.iter().product();
+        let mut out = vec![0.0; out_len];
+
+        // Prepare padded shapes and strides for easier index mapping.
+        let mut src_shape = vec![1; target.len()];
+        let offset = target.len() - self.shape.len();
+        for (i, &dim) in self.shape.iter().enumerate() {
+            src_shape[offset + i] = dim;
+        }
+        let mut src_stride = vec![0; target.len()];
+        let mut stride = 1;
+        for (i, dim) in src_shape.iter().rev().enumerate() {
+            src_stride[src_shape.len() - 1 - i] = stride;
+            stride *= *dim;
+        }
+
+        for i in 0..out_len {
+            // Decode `i` into indices of the target shape and compute the
+            // corresponding source index.
+            let mut tmp = i;
+            let mut src_index = 0usize;
+            for ((&t_dim, &s_dim), &s_stride) in target
+                .iter()
+                .rev()
+                .zip(src_shape.iter().rev())
+                .zip(src_stride.iter().rev())
+            {
+                let idx = tmp % t_dim;
+                tmp /= t_dim;
+                let s_idx = if s_dim == 1 { 0 } else { idx };
+                src_index += s_idx * s_stride;
+            }
+            out[i] = self.data[src_index];
+        }
+
+        Tensor {
+            data: out,
+            shape: target.to_vec(),
+        }
+    }
+
+    /// Elementwise addition with broadcasting handled by the math helper.
     pub fn add(a: &Tensor, b: &Tensor) -> Tensor {
-        let data = a.data.add(&b.data);
-        Tensor::from_matrix(data)
+        math::tensor_add(a, b)
     }
 
+    /// Matrix multiplication treating the last two dimensions as matrices.
     pub fn matmul(a: &Tensor, b: &Tensor) -> Tensor {
-        let data = Matrix::matmul(&a.data, &b.data);
-        Tensor::from_matrix(data)
+        math::tensor_matmul(a, b)
     }
 
+    /// Transpose a 2-D tensor.
     pub fn transpose(t: &Tensor) -> Tensor {
-        Tensor::from_matrix(t.data.transpose())
+        math::tensor_transpose(t)
     }
 
+    /// Softmax along the last dimension.
     pub fn softmax(t: &Tensor) -> Tensor {
-        let data = t.data.softmax();
-        Tensor::from_matrix(data)
+        math::tensor_softmax(t)
     }
 
     /// Compute cross-entropy loss and gradient w.r.t. the logits contained in
     /// this tensor.  The returned gradient tensor can be fed directly into a
     /// backward pass of subsequent layers.
     #[allow(dead_code)]
-    pub fn softmax_cross_entropy(&self, targets: &[usize], row_offset: usize) -> (f32, Tensor) {
-        let (loss, grad, _) = math::softmax_cross_entropy(&self.data, targets, row_offset);
-        (loss, Tensor::from_matrix(grad))
+    pub fn softmax_cross_entropy(
+        &self,
+        targets: &[usize],
+        row_offset: usize,
+    ) -> (f32, Tensor) {
+        let (loss, grad) = math::tensor_softmax_cross_entropy(self, targets, row_offset);
+        (loss, grad)
     }
 }
+

--- a/tests/tensor_broadcast.rs
+++ b/tests/tensor_broadcast.rs
@@ -1,0 +1,20 @@
+use vanillanoprop::tensor::Tensor;
+
+#[test]
+fn broadcast_add_works() {
+    let a = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+    let b = Tensor::new(vec![1.0, 2.0, 3.0], vec![1, 3]);
+    let c = Tensor::add(&a, &b);
+    assert_eq!(c.shape, vec![2, 3]);
+    assert_eq!(c.data, vec![2.0, 4.0, 6.0, 5.0, 7.0, 9.0]);
+}
+
+#[test]
+fn reshape_and_index() {
+    let mut t = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]);
+    assert_eq!(t.get(&[1, 1]), 4.0);
+    t.reshape(vec![4]);
+    assert_eq!(t.shape, vec![4]);
+    assert_eq!(t.get(&[3]), 4.0);
+}
+


### PR DESCRIPTION
## Summary
- replace Tensor's Matrix backing with flat Vec and shape metadata
- add tensor-aware math helpers for addition, matmul, transpose and softmax
- test indexing, reshape and broadcasting semantics

## Testing
- `cargo test` *(fails: failed to parse lock file at: /workspace/vanillanoprop/Cargo.lock)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ca9cd434832fa7be9d8512638cef