### PR TITLE
Add basic autograd node and example

### DIFF
--- a/examples/autograd_custom_layer.rs
+++ b/examples/autograd_custom_layer.rs
@@ -1,0 +1,27 @@
+use vanillanoprop::tensor::{Node, NodeRef, Tensor};
+
+struct MyLayer {
+    weight: NodeRef,
+}
+
+impl MyLayer {
+    fn new() -> Self {
+        // Single weight parameter initialised to 2.0
+        let w = Tensor::new(vec![2.0], vec![1, 1]).into_node(true);
+        Self { weight: w }
+    }
+
+    fn forward(&self, x: &NodeRef) -> NodeRef {
+        // Simple linear layer y = x * w
+        Node::matmul(x, &self.weight)
+    }
+}
+
+fn main() {
+    let layer = MyLayer::new();
+    let x = Tensor::new(vec![3.0], vec![1, 1]).into_node(true);
+    let y = layer.forward(&x);
+    Node::backward(&y);
+    println!("grad x: {:?}", x.borrow().grad.as_ref().unwrap().data);
+    println!("grad w: {:?}", layer.weight.borrow().grad.as_ref().unwrap().data);
+}


### PR DESCRIPTION
## Summary
- add rudimentary autograd `Node` structure with backward propagation for add, matmul, transpose, and softmax
- provide Tensor helpers for gradient initialisation and conversion into graph nodes
- include example demonstrating a custom layer built on the computation graph

## Testing
- `cargo test` *(fails: could not compile `vanillanoprop` due to multiple errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d848ba58832f94b46a8f184237a4