### PR TITLE
Add in-place tensor softmax and reuse in cross-entropy

### DIFF
--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -138,15 +138,22 @@ impl Tensor {
         math::tensor_softmax(t)
     }
 
+    /// Softmax along the last dimension, writing the result into `out`.
+    /// The input tensor `t` is not modified.
+    pub fn softmax_into(out: &mut Tensor, t: &Tensor) {
+        math::tensor_softmax_into(out, t)
+    }
+
+    /// In-place softmax along the last dimension.
+    pub fn softmax_inplace(&mut self) {
+        math::tensor_softmax_inplace(self)
+    }
+
     /// Compute cross-entropy loss and gradient w.r.t. the logits contained in
     /// this tensor.  The returned gradient tensor can be fed directly into a
     /// backward pass of subsequent layers.
     #[allow(dead_code)]
-    pub fn softmax_cross_entropy(
-        &self,
-        targets: &[usize],
-        row_offset: usize,
-    ) -> (f32, Tensor) {
+    pub fn softmax_cross_entropy(&self, targets: &[usize], row_offset: usize) -> (f32, Tensor) {
         let (loss, grad) = math::tensor_softmax_cross_entropy(self, targets, row_offset);
         (loss, grad)
     }
@@ -355,5 +362,3 @@ impl Node {
         }
     }
 }
-
-


### PR DESCRIPTION
## Summary
- Add in-place `tensor_softmax_inplace` with helpers for writing into an output tensor or allocating anew
- Expose `Tensor::softmax_into` and `Tensor::softmax_inplace` APIs
- Rework `tensor_softmax_cross_entropy` to reuse in-place softmax buffer

## Testing
- `cargo test` *(fails: no field `rows` on type `Vec<f32>` ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e96ad980832f88937a04e28bbfdc