### PR TITLE
Avoid redundant Tensor conversions in RNN prediction

### DIFF
--- a/src/predict.rs
+++ b/src/predict.rs
@@ -144,9 +144,10 @@ pub fn run(model: Option<&str>, moe: bool, num_experts: usize) {
                         MixtureOfExpertsT::new(hidden_dim, experts, 1)
                     }
                 };
+                let enc_x = Tensor::from_matrix(enc_x);
                 let h = match &model.cell {
-                    RnnCell::LSTM(l) => l.forward(&Tensor::from_matrix(enc_x.clone())),
-                    RnnCell::GRU(g) => g.forward(&Tensor::from_matrix(enc_x.clone())),
+                    RnnCell::LSTM(l) => l.forward(&enc_x),
+                    RnnCell::GRU(g) => g.forward(&enc_x),
                 };
                 let last_row = h.data.rows - 1;
                 let mut last = Matrix::zeros(1, h.data.cols);


### PR DESCRIPTION
## Summary
- Avoid cloning `enc_x` when running RNN predictions by converting once to a Tensor and reusing it

## Testing
- `cargo check` *(fails: no field `cols` on type `Vec<f32>` in weights.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b1eca07c18832fa512b5284e8b0b7b