### PR TITLE
Refactor DataLoader to yield slice batches

### DIFF
--- a/docs/examples/data_loader.md
+++ b/docs/examples/data_loader.md
@@ -11,7 +11,7 @@ use vanillanoprop::data::{DataLoader, Mnist};
 // and shuffling enabled.
 let loader = DataLoader::<Mnist>::new(32, true, None);
 for batch in loader {
-    // `batch` is a `Vec<(Vec<u8>, usize)>`
+    // `batch` is a `&[(Vec<u8>, usize)]`
     // ... perform training ...
 }
 ```

--- a/src/bin/compare.rs
+++ b/src/bin/compare.rs
@@ -10,7 +10,6 @@ use vanillanoprop::models::SimpleCNN;
 
 // Train a SimpleCNN with standard backpropagation using a basic SGD loop.
 fn train_backprop(epochs: usize) -> (f32, usize, usize, u64) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> = DataLoader::<Mnist>::new(4, true, None).collect();
     let mut cnn = SimpleCNN::new(10);
 
     let lr = 0.01f32;
@@ -25,7 +24,7 @@ fn train_backprop(epochs: usize) -> (f32, usize, usize, u64) {
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
 
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(4, true, None) {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
 
@@ -79,7 +78,6 @@ fn train_backprop(epochs: usize) -> (f32, usize, usize, u64) {
 
 // Train a SimpleCNN using a NoProp-style local update with noisy targets.
 fn train_noprop(epochs: usize) -> (f32, usize, usize, u64) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> = DataLoader::<Mnist>::new(4, true, None).collect();
     let mut cnn = SimpleCNN::new(10);
     let mut rng = rng_from_env();
 
@@ -95,7 +93,7 @@ fn train_noprop(epochs: usize) -> (f32, usize, usize, u64) {
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
 
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(4, true, None) {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
 

--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -78,8 +78,6 @@ fn run(
     resume: Option<String>,
     fine_tune: Option<vanillanoprop::fine_tune::FineTune>,
 ) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     let vocab_size = 256;
 
     let model_dim = 64;
@@ -145,7 +143,7 @@ fn run(
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             encoder.zero_grad();
             decoder.zero_grad();
             let mut batch_loss = 0.0f32;

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -64,8 +64,6 @@ fn run(
     experiment: Option<String>,
     config: &Config,
 ) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     let vocab_size = 256;
 
     // With embedding → model_dim separate
@@ -100,7 +98,7 @@ fn run(
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             encoder.zero_grad();
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;

--- a/src/bin/train_lcm.rs
+++ b/src/bin/train_lcm.rs
@@ -36,8 +36,6 @@ fn main() {
 }
 
 fn run(config: &Config) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     let mut model = LargeConceptModel::new(28 * 28, 128, 64, 10);
     let lr = 0.01f32;
     let l2 = 1e-4f32;
@@ -48,7 +46,7 @@ fn run(config: &Config) {
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (img, tgt) in batch {

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -108,8 +108,6 @@ fn run(
     experiment_name: Option<String>,
     config: &Config,
 ) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     let mut rng = rng_from_env();
     let vocab_size = 256;
 
@@ -175,7 +173,7 @@ fn run(
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (src, tgt) in batch {

--- a/src/bin/train_resnet.rs
+++ b/src/bin/train_resnet.rs
@@ -48,8 +48,6 @@ fn run(
     experiment_name: Option<String>,
     config: &Config,
 ) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     // 64 hidden units and 2 residual blocks as a default configuration.
     let mut net = ResNet::new(10, 64, 2);
 
@@ -80,7 +78,7 @@ fn run(
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (img, tgt) in batch {

--- a/src/bin/train_rnn.rs
+++ b/src/bin/train_rnn.rs
@@ -48,8 +48,6 @@ fn run(
     config: &Config,
     fine_tune: Option<vanillanoprop::fine_tune::FineTune>,
 ) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     let vocab_size = 256; // pixel values 0-255
     let hidden_dim = 64;
     let num_classes = 10;
@@ -73,7 +71,7 @@ fn run(
 
     for epoch in 0..epochs {
         let mut last_loss = 0.0;
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             rnn.zero_grad();
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;

--- a/src/bin/train_vae.rs
+++ b/src/bin/train_vae.rs
@@ -8,7 +8,7 @@ use vanillanoprop::weights::save_vae;
 fn main() {
     let pairs: Vec<(Vec<u8>, usize)> = DataLoader::<Mnist>::new(1, true, None)
         .take(10)
-        .flat_map(|b| b.into_iter())
+        .flat_map(|b| b.iter().cloned())
         .collect();
     let input_dim = 28 * 28;
     let hidden_dim = 400;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -17,7 +17,7 @@ fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
 pub fn run(model: Option<&str>, moe: bool, num_experts: usize) {
     // pick a random image from the MNIST training pairs
     let pairs: Vec<(Vec<u8>, usize)> = DataLoader::<Mnist>::new(1, true, None)
-        .flat_map(|b| b.into_iter())
+        .flat_map(|b| b.iter().cloned())
         .collect();
     let mut rng = thread_rng();
     let idx = rng.gen_range(0..pairs.len());

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -45,8 +45,6 @@ pub fn run(
     config: &Config,
     mut callbacks: Vec<Box<dyn Callback>>,
 ) {
-    let batches: Vec<Vec<(Vec<u8>, usize)>> =
-        DataLoader::<Mnist>::new(config.batch_size, true, None).collect();
     let mut cnn = SimpleCNN::new(10);
     let mut moe_layer = if moe {
         let n = num_experts.max(1);
@@ -118,7 +116,7 @@ pub fn run(
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
 
-        for batch in &batches {
+        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
 


### PR DESCRIPTION
## Summary
- make DataLoader yield slice batches instead of owned Vecs
- update training scripts and examples to use slice batches

## Testing
- `cargo test --lib` *(fails: no field `cols` on type `Vec<f32>` in weights.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f71eabb8832fb3703e6ce7a8af72