### PR TITLE
Add slice-based Matrix views for matmul

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -22,7 +22,7 @@ pub struct Cpu;
 
 impl Device for Cpu {
     fn matmul(&self, a: &Matrix, b: &Matrix) -> Matrix {
-        matmul_cpu(a, b)
+        matmul_cpu(a.as_view(), b.as_view())
     }
 }
 


### PR DESCRIPTION
## Summary
- add `Matrix::from_slice` and `Matrix::as_view` to create non-owning matrix views
- refactor `matmul_cpu` to operate on `MatrixView`
- avoid cloning tensors in `tensor_matmul` by wrapping data slices
- call `matmul_cpu` on matrix views in CPU device

## Testing
- `cargo test --no-default-features` *(fails: could not compile `vanillanoprop`)*

------
https://chatgpt.com/codex/tasks/task_e_68b20bc6b218832fa73e7d22d84165ed