### PR TITLE
Add optional quantization paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
     /// provided the [`automl`](crate::automl) module will explore them.
     #[serde(default = "default_learning_rates")]
     pub learning_rate: Vec<f32>,
+    /// Whether to enable quantized inference where supported.
+    #[serde(default)]
+    pub quantized: bool,
 }
 
 fn default_epochs() -> usize {
@@ -74,6 +77,7 @@ impl Default for Config {
             max_depth: default_max_depth(),
             rollout_steps: default_rollout_steps(),
             learning_rate: default_learning_rates(),
+            quantized: false,
         }
     }
 }

--- a/src/layers/embedding.rs
+++ b/src/layers/embedding.rs
@@ -1,7 +1,7 @@
-use crate::tensor::Tensor;
-use crate::math::Matrix;
-use super::linear::LinearT;
 use super::layer::Layer;
+use super::linear::LinearT;
+use crate::math::Matrix;
+use crate::tensor::Tensor;
 
 /// Embedding layer: maps one-hot (vocab_size) into dense model_dim.
 pub struct EmbeddingT {
@@ -18,6 +18,11 @@ impl EmbeddingT {
     pub fn forward(&self, x: &Tensor) -> Tensor {
         // inference helper
         Tensor::matmul(x, &self.table.w)
+    }
+
+    /// Quantized inference helper performing int8 matrix multiplication.
+    pub fn quantized_matmul(&self, x: &Tensor) -> Tensor {
+        self.table.quantized_matmul(x)
     }
 
     pub fn forward_local(&mut self, x: &Matrix) -> Matrix {
@@ -41,8 +46,7 @@ impl EmbeddingT {
     }
 
     pub fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
-        self.table
-            .adam_step(lr, beta1, beta2, eps, weight_decay);
+        self.table.adam_step(lr, beta1, beta2, eps, weight_decay);
     }
 
     pub fn parameters(&mut self) -> Vec<&mut LinearT> {
@@ -71,14 +75,7 @@ impl Layer for EmbeddingT {
         EmbeddingT::fa_update(self, grad_out, lr)
     }
 
-    fn adam_step(
-        &mut self,
-        lr: f32,
-        beta1: f32,
-        beta2: f32,
-        eps: f32,
-        weight_decay: f32,
-    ) {
+    fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
         EmbeddingT::adam_step(self, lr, beta1, beta2, eps, weight_decay);
     }
 
@@ -86,4 +83,3 @@ impl Layer for EmbeddingT {
         EmbeddingT::parameters(self)
     }
 }
-

--- a/treepo_config.toml
+++ b/treepo_config.toml
@@ -4,3 +4,4 @@ max_depth = 10
 rollout_steps = 10
 learning_rate = 0.1
 episodes = 10
+quantized = false


### PR DESCRIPTION
## Summary
- add quantize/dequantize helpers for tensors and raw weights
- expose quantized matmul for LinearT and EmbeddingT layers
- allow enabling quantized inference via config flag

## Testing
- `cargo test` *(fails: could not compile `vanillanoprop` (lib) due to 128 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b27ddbb954832fb8fb5838d3b302a9