### PR TITLE
Refactor tensor handling in RNN and activation layers

### DIFF
--- a/src/layers/rnn.rs
+++ b/src/layers/rnn.rs
@@ -123,8 +123,12 @@ impl LSTM {
         let mut h_prev = Matrix::zeros(1, self.hidden_dim);
         let mut c_prev = Matrix::zeros(1, self.hidden_dim);
         let mut outs = Vec::new();
-        for t in 0..x.data.rows {
-            let x_t = Matrix::from_vec(1, self.input_dim, x.data.data[t*self.input_dim..(t+1)*self.input_dim].to_vec());
+        for t in 0..x.shape[0] {
+            let x_t = Matrix::from_vec(
+                1,
+                self.input_dim,
+                x.data[t * self.input_dim..(t + 1) * self.input_dim].to_vec(),
+            );
             let (h_t, c_t, _, _, _, _) = self.step(&x_t, &h_prev, &c_prev);
             h_prev = h_t.clone();
             c_prev = c_t;
@@ -324,8 +328,12 @@ impl GRU {
     pub fn forward(&self, x: &Tensor) -> Tensor {
         let mut h_prev = Matrix::zeros(1, self.hidden_dim);
         let mut outs = Vec::new();
-        for t in 0..x.data.rows {
-            let x_t = Matrix::from_vec(1, self.input_dim, x.data.data[t*self.input_dim..(t+1)*self.input_dim].to_vec());
+        for t in 0..x.shape[0] {
+            let x_t = Matrix::from_vec(
+                1,
+                self.input_dim,
+                x.data[t * self.input_dim..(t + 1) * self.input_dim].to_vec(),
+            );
             let (h_t, _, _, _) = self.step(&x_t, &h_prev);
             h_prev = h_t.clone();
             outs.push(h_prev.clone());

--- a/src/layers/sigmoid.rs
+++ b/src/layers/sigmoid.rs
@@ -3,7 +3,7 @@ use crate::tensor::Tensor;
 
 /// Apply sigmoid activation in place on a tensor.
 pub fn forward_tensor(t: &mut Tensor) {
-    for v in t.data.data.iter_mut() {
+    for v in t.data.iter_mut() {
         *v = 1.0 / (1.0 + (-*v).exp());
     }
 }

--- a/src/layers/softmax.rs
+++ b/src/layers/softmax.rs
@@ -37,7 +37,8 @@ impl SoftmaxT {
     }
 
     pub fn forward(&self, x: &Tensor) -> Tensor {
-        let data = Self::forward_internal(&x.data);
+        let m = Matrix::from_vec(x.shape[0], x.shape[1], x.data.clone());
+        let data = Self::forward_internal(&m);
         Tensor::from_matrix(data)
     }
 

--- a/src/layers/tanh.rs
+++ b/src/layers/tanh.rs
@@ -3,7 +3,7 @@ use crate::tensor::Tensor;
 
 /// Apply tanh activation in place on a tensor.
 pub fn forward_tensor(t: &mut Tensor) {
-    for v in t.data.data.iter_mut() {
+    for v in t.data.iter_mut() {
         *v = v.tanh();
     }
 }


### PR DESCRIPTION
## Summary
- use Tensor shape and raw data slices in RNN forward passes
- iterate over tensor data directly in sigmoid and tanh activations
- convert tensors to matrices in Softmax forward

## Testing
- `cargo test` *(fails: could not compile `vanillanoprop` due to 121 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2861658cc832fbf20e912efe89d1c