### PR TITLE
Use tensor shape instead of matrix dimensions

### DIFF
--- a/examples/hf_transformer.rs
+++ b/examples/hf_transformer.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let h = enc.forward(x, None);
-    println!("Output shape: {}x{}", h.data.rows, h.data.cols);
+    println!("Output shape: {}x{}", h.shape[0], h.shape[1]);
 
     Ok(())
 }

--- a/src/models/decoder.rs
+++ b/src/models/decoder.rs
@@ -41,7 +41,7 @@ impl DecoderLayerT {
 
     pub fn forward(&self, x: &Tensor, enc_out: &Tensor) -> Tensor {
         let h1 = self.self_attn.forward(x);
-        let ctx = if h1.data.rows == enc_out.data.rows && h1.data.cols == enc_out.data.cols {
+        let ctx = if h1.shape[0] == enc_out.shape[0] && h1.shape[1] == enc_out.shape[1] {
             Tensor::add(&h1, enc_out)
         } else {
             h1

--- a/src/models/encoder.rs
+++ b/src/models/encoder.rs
@@ -114,7 +114,7 @@ impl EncoderT {
         // existing inference path
         let mut h = Tensor::from_matrix(x);
         h = self.embedding.forward(&h);
-        let pos = positional_encoding(h.data.rows, h.data.cols);
+        let pos = positional_encoding(h.shape[0], h.shape[1]);
         let p = Tensor::from_matrix(pos);
         h = Tensor::add(&h, &p);
         for l in &self.layers {

--- a/src/models/rnn.rs
+++ b/src/models/rnn.rs
@@ -50,10 +50,11 @@ impl RNN {
             RnnCell::GRU(g) => g.forward(x),
         };
         // take last hidden state
-        let last_row = h.data.rows - 1;
-        let mut last = Matrix::zeros(1, h.data.cols);
-        for c in 0..h.data.cols {
-            last.set(0, c, h.data.get(last_row, c));
+        let last_row = h.shape[0] - 1;
+        let mut last = Matrix::zeros(1, h.shape[1]);
+        for c in 0..h.shape[1] {
+            let idx = last_row * h.shape[1] + c;
+            last.set(0, c, h.data[idx]);
         }
         self.fc.forward(&Tensor::from_matrix(last))
     }

--- a/src/models/transformer.rs
+++ b/src/models/transformer.rs
@@ -138,7 +138,7 @@ impl TransformerEncoder {
     pub fn forward(&mut self, one_hot_x: Matrix, mask: Option<&Matrix>) -> Tensor {
         let mut h = Tensor::from_matrix(one_hot_x);
         h = self.embedding.forward(&h);
-        let pos = positional_encoding(h.data.rows, h.data.cols);
+        let pos = positional_encoding(h.shape[0], h.shape[1]);
         let p = Tensor::from_matrix(pos);
         h = Tensor::add(&h, &p);
         for layer in self.layers.iter_mut() {

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -22,7 +22,7 @@ impl Tensor {
     /// Create a new tensor from raw parts.  The number of elements in `data`
     /// must match the product of the requested `shape`.
     pub fn new(data: Vec<f32>, shape: Vec<usize>) -> Self {
-        assert_eq!(data.len(), shape.iter().product());
+        assert_eq!(data.len(), shape.iter().product::<usize>());
         Tensor { data, shape }
     }
 
@@ -65,7 +65,7 @@ impl Tensor {
     /// Change the view of the underlying data without modifying order.
     /// The new shape must contain the same number of elements.
     pub fn reshape(&mut self, new_shape: Vec<usize>) {
-        assert_eq!(self.data.len(), new_shape.iter().product());
+        assert_eq!(self.data.len(), new_shape.iter().product::<usize>());
         self.shape = new_shape;
     }
 


### PR DESCRIPTION
## Summary
- Switch row/column access to `tensor.shape` across prediction and model modules
- Compute flat indices for tensor element access instead of Matrix::get
- Fix tensor constructors to use explicit `usize` products

## Testing
- `cargo test` *(fails: no field `rows` on type `Vec<f32>` and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b28738e65c832fb74adcbbf2cf6195