### PR TITLE
Refactor tensor ops to use matrices and adjust examples

### DIFF
--- a/examples/autoencoder.rs
+++ b/examples/autoencoder.rs
@@ -1,13 +1,12 @@
-use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::data::{DataLoader, Mnist};
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::VAE;
 
 fn main() {
     // Use dataset utilities to load MNIST in mini-batches
-    let batches = Mnist::batch(16);
     let mut vae = VAE::new(28 * 28, 128, 32);
 
-    for (i, batch) in batches.iter().take(3).enumerate() {
+    for (i, batch) in DataLoader::<Mnist>::new(16, true, None).take(3).enumerate() {
         let mut loss_sum = 0.0f32;
         for (img, _) in batch {
             let input: Vec<f32> = img.iter().map(|&p| p as f32 / 255.0).collect();

--- a/examples/mixture_of_experts.rs
+++ b/examples/mixture_of_experts.rs
@@ -36,5 +36,5 @@ fn main() {
         }
     }
     let probs = moe.softmax.forward(&Tensor::from_matrix(logits));
-    println!("Gating probabilities: {:?}", probs.data.data);
+    println!("Gating probabilities: {:?}", probs.data);
 }

--- a/examples/mnist_cnn.rs
+++ b/examples/mnist_cnn.rs
@@ -1,12 +1,11 @@
-use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::data::{DataLoader, Mnist};
 use vanillanoprop::layers::{Layer, LinearT, MixtureOfExpertsT};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::models::SimpleCNN;
 use vanillanoprop::weights::save_moe;
 
 fn main() {
-    // Load MNIST and group into mini-batches using the Dataset API.
-    let batches = Mnist::batch(32);
+    // Load MNIST and group into mini-batches using the DataLoader.
     let cnn = SimpleCNN::new(10);
     let lr = 0.01f32;
     let experts: Vec<Box<dyn Layer>> = (0..3)
@@ -14,7 +13,7 @@ fn main() {
         .collect();
     let mut moe = MixtureOfExpertsT::new(28 * 28, experts, 1);
 
-    for (i, batch) in batches.iter().take(5).enumerate() {
+    for (i, batch) in DataLoader::<Mnist>::new(32, true, None).take(5).enumerate() {
         let mut loss_sum = 0.0f32;
         for (img, label) in batch {
             let (feat, _logits) = cnn.forward(img);

--- a/examples/mnist_gan.rs
+++ b/examples/mnist_gan.rs
@@ -1,14 +1,13 @@
 use rand::Rng;
-use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::data::{DataLoader, Mnist};
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::GAN;
 use vanillanoprop::rng::rng_from_env;
 
 fn main() {
-    let batches = Mnist::batch(32);
     let mut gan = GAN::new(100);
     let mut rng = rng_from_env();
-    for (i, batch) in batches.iter().take(2).enumerate() {
+    for (i, batch) in DataLoader::<Mnist>::new(32, true, None).take(2).enumerate() {
         let mut d_loss_sum = 0.0f32;
         let mut g_loss_sum = 0.0f32;
         for (img, _) in batch {

--- a/examples/mnist_vgg.rs
+++ b/examples/mnist_vgg.rs
@@ -1,14 +1,13 @@
-use vanillanoprop::data::{Dataset, Mnist};
+use vanillanoprop::data::{DataLoader, Mnist};
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::models::VGG;
 
 fn main() {
     // Use a small VGG-style network with three blocks of [1,1,2] conv layers.
-    let batches = Mnist::batch(32);
     let mut vgg = VGG::new(&[1, 1, 2], 10);
     let lr = 0.01f32;
 
-    for (i, batch) in batches.iter().take(5).enumerate() {
+    for (i, batch) in DataLoader::<Mnist>::new(32, true, None).take(5).enumerate() {
         let mut loss_sum = 0.0f32;
         for (img, label) in batch {
             let (feat, logits) = vgg.forward(img);

--- a/examples/sequential_mlp.rs
+++ b/examples/sequential_mlp.rs
@@ -35,5 +35,5 @@ fn main() {
     // Inference with Tensor input
     let tensor_input = Tensor::from_matrix(input);
     let output = mlp.forward(&tensor_input);
-    println!("model output: {:?}", output.data.data);
+    println!("model output: {:?}", output.data);
 }

--- a/examples/text_rnn.rs
+++ b/examples/text_rnn.rs
@@ -1,40 +1,25 @@
-use vanillanoprop::data::Dataset;
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::models::RNN;
 
-// Tiny in-memory dataset of sequences with binary labels.
-struct ToyText;
-
-impl Dataset for ToyText {
-    type Item = (Vec<Vec<f32>>, u8);
-
-    fn load() -> Vec<Self::Item> {
-        vec![
-            (vec![vec![1.0], vec![2.0], vec![3.0]], 1),
-            (vec![vec![3.0], vec![2.0], vec![1.0]], 0),
-            (vec![vec![0.5], vec![1.5], vec![0.5]], 1),
-            (vec![vec![1.5], vec![0.5], vec![1.5]], 0),
-        ]
-    }
-}
-
 fn main() {
-    let batches = ToyText::batch(2);
+    let data = vec![
+        (vec![vec![1.0], vec![2.0], vec![3.0]], 1u8),
+        (vec![vec![3.0], vec![2.0], vec![1.0]], 0u8),
+        (vec![vec![0.5], vec![1.5], vec![0.5]], 1u8),
+        (vec![vec![1.5], vec![0.5], vec![1.5]], 0u8),
+    ];
     let mut rnn = RNN::new_lstm(1, 4, 2);
-
-    for (i, batch) in batches.iter().enumerate() {
-        for (seq, label) in batch {
-            // Convert sequence to Matrix (time_steps x input_dim)
-            let mut mat = Matrix::zeros(seq.len(), 1);
-            for (t, token) in seq.iter().enumerate() {
-                mat.set(t, 0, token[0]);
-            }
-            let logits = rnn.forward_train(&mat);
-            let (loss, grad, _) = math::softmax_cross_entropy(&logits, &[*label as usize], 0);
-            rnn.zero_grad();
-            rnn.backward(&grad);
-            rnn.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
-            println!("batch {i} sample loss {loss}");
+    for (i, (seq, label)) in data.iter().enumerate() {
+        // Convert sequence to Matrix (time_steps x input_dim)
+        let mut mat = Matrix::zeros(seq.len(), 1);
+        for (t, token) in seq.iter().enumerate() {
+            mat.set(t, 0, token[0]);
         }
+        let logits = rnn.forward_train(&mat);
+        let (loss, grad, _) = math::softmax_cross_entropy(&logits, &[*label as usize], 0);
+        rnn.zero_grad();
+        rnn.backward(&grad);
+        rnn.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
+        println!("sample {i} loss {loss}");
     }
 }

--- a/examples/text_transformer.rs
+++ b/examples/text_transformer.rs
@@ -1,22 +1,6 @@
-use vanillanoprop::data::Dataset;
 use vanillanoprop::layers::LinearT;
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::models::TransformerEncoder;
-
-struct ToyText;
-
-impl Dataset for ToyText {
-    type Item = (Vec<usize>, u8);
-
-    fn load() -> Vec<Self::Item> {
-        vec![
-            (vec![1, 2, 3], 1),
-            (vec![3, 2, 1], 0),
-            (vec![0, 1, 2], 1),
-            (vec![2, 1, 0], 0),
-        ]
-    }
-}
 
 fn to_one_hot(seq: &[usize], vocab: usize) -> Matrix {
     let mut m = Matrix::zeros(seq.len(), vocab);
@@ -28,28 +12,31 @@ fn to_one_hot(seq: &[usize], vocab: usize) -> Matrix {
 
 fn main() {
     let vocab = 4;
-    let batches = ToyText::batch(2);
+    let data = vec![
+        (vec![1, 2, 3], 1u8),
+        (vec![3, 2, 1], 0u8),
+        (vec![0, 1, 2], 1u8),
+        (vec![2, 1, 0], 0u8),
+    ];
     let mut enc = TransformerEncoder::new(2, vocab, 8, 2, 16, 0.1);
     let mut clf = LinearT::new(8, 2);
 
-    for (i, batch) in batches.iter().enumerate() {
-        for (seq, label) in batch {
-            let x = to_one_hot(seq, vocab);
-            let h = enc.forward_train(&x, None);
-            // take representation of first token
-            let mut cls = Matrix::zeros(1, h.cols);
-            for c in 0..h.cols { cls.set(0, c, h.get(0, c)); }
-            let logits = clf.forward_train(&cls);
-            let (loss, grad, _) = math::softmax_cross_entropy(&logits, &[*label as usize], 0);
-            clf.zero_grad();
-            enc.zero_grad();
-            let grad_cls = clf.backward(&grad);
-            let mut grad_enc = Matrix::zeros(h.rows, h.cols);
-            for c in 0..h.cols { grad_enc.set(0, c, grad_cls.get(0, c)); }
-            enc.backward(&grad_enc);
-            clf.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
-            enc.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
-            println!("batch {i} loss {loss}");
-        }
+    for (i, (seq, label)) in data.iter().enumerate() {
+        let x = to_one_hot(seq, vocab);
+        let h = enc.forward_train(&x, None);
+        // take representation of first token
+        let mut cls = Matrix::zeros(1, h.cols);
+        for c in 0..h.cols { cls.set(0, c, h.get(0, c)); }
+        let logits = clf.forward_train(&cls);
+        let (loss, grad, _) = math::softmax_cross_entropy(&logits, &[*label as usize], 0);
+        clf.zero_grad();
+        enc.zero_grad();
+        let grad_cls = clf.backward(&grad);
+        let mut grad_enc = Matrix::zeros(h.rows, h.cols);
+        for c in 0..h.cols { grad_enc.set(0, c, grad_cls.get(0, c)); }
+        enc.backward(&grad_enc);
+        clf.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
+        enc.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
+        println!("sample {i} loss {loss}");
     }
 }

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -137,8 +137,8 @@ fn run(
         if let Ok(cp) = load_checkpoint::<NopropCheckpoint>(path) {
             if !cp.model.encoder_embedding.is_empty() {
                 let mut params = encoder.embedding.parameters();
-                let exp_rows = params[0].w.data.rows;
-                let exp_cols = params[0].w.data.cols;
+                let exp_rows = params[0].w.shape[0];
+                let exp_cols = params[0].w.shape[1];
                 let loaded = vec2_to_matrix(&cp.model.encoder_embedding);
                 let mut mat = Matrix::zeros(exp_rows, exp_cols);
                 for r in 0..loaded.rows.min(exp_rows) {
@@ -191,7 +191,7 @@ fn run(
                 let mut tgt_mat = Matrix::zeros(1, vocab_size);
                 tgt_mat.set(0, tgt as usize, 1.0);
                 let mut noisy = encoder.forward(tgt_mat);
-                for v in &mut noisy.data.data {
+                for v in &mut noisy.data {
                     *v += (rng.gen::<f32>() - 0.5) * 0.1;
                 }
 
@@ -199,7 +199,7 @@ fn run(
                 let mut delta = Matrix::zeros(enc_out.rows, enc_out.cols);
                 let mut loss = 0.0f32;
                 for i in 0..len * model_dim {
-                    let d = enc_out.data[i] - noisy.data.data[i];
+                    let d = enc_out.data[i] - noisy.data[i];
                     loss += d * d;
                     delta.data[i] = 2.0 * d;
                 }

--- a/src/export/onnx.rs
+++ b/src/export/onnx.rs
@@ -85,8 +85,8 @@ fn add_linear(layer: &LinearT, input: &str, output: &str, graph: &mut GraphProto
     let weight = TensorProto {
         name: weight_name.clone(),
         data_type: DataType::Float as i32,
-        dims: vec![layer.w.data.rows as i64, layer.w.data.cols as i64],
-        float_data: layer.w.data.data.clone(),
+        dims: vec![layer.w.shape[0] as i64, layer.w.shape[1] as i64],
+        float_data: layer.w.data.clone(),
         ..Default::default()
     };
     graph.initializer.push(weight);
@@ -110,7 +110,7 @@ fn add_conv(layer: &Conv2d, input: &str, output: &str, graph: &mut GraphProto) {
             layer.kernel_size() as i64,
             layer.kernel_size() as i64,
         ],
-        float_data: layer.w.w.data.data.clone(),
+        float_data: layer.w.w.data.clone(),
         ..Default::default()
     };
     graph.initializer.push(weight);

--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -319,10 +319,13 @@ impl Conv2d {
     }
 
     pub fn forward(&self, x: &Tensor) -> Result<Tensor, ConvError> {
-        let (batch, in_h, in_w, out_h, out_w) = self.compute_shapes(&x.data)?;
-        let cols = self.im2col(&x.data, in_h, in_w, out_h, out_w);
-        let out_cols = self.w.forward(&Tensor::from_matrix(cols));
-        let out = self.reshape_output(&out_cols.data, batch, out_h, out_w);
+        let x_m = Matrix::from_vec(x.shape[0], x.shape[1], x.data.clone());
+        let (batch, in_h, in_w, out_h, out_w) = self.compute_shapes(&x_m)?;
+        let cols = self.im2col(&x_m, in_h, in_w, out_h, out_w);
+        let out_cols_t = self.w.forward(&Tensor::from_matrix(cols));
+        let out_cols =
+            Matrix::from_vec(out_cols_t.shape[0], out_cols_t.shape[1], out_cols_t.data.clone());
+        let out = self.reshape_output(&out_cols, batch, out_h, out_w);
         Ok(Tensor::from_matrix(out))
     }
 

--- a/src/layers/leaky_relu.rs
+++ b/src/layers/leaky_relu.rs
@@ -5,7 +5,7 @@ const SLOPE: f32 = 0.01;
 
 /// Apply leaky ReLU activation in place on a tensor.
 pub fn forward_tensor(t: &mut Tensor) {
-    for v in t.data.data.iter_mut() {
+    for v in t.data.iter_mut() {
         if *v < 0.0 {
             *v *= SLOPE;
         }

--- a/src/layers/normalization.rs
+++ b/src/layers/normalization.rs
@@ -99,13 +99,13 @@ impl BatchNorm {
     }
 
     pub fn forward(&self, x: &Tensor) -> Tensor {
-        let rows = x.data.rows;
-        let cols = x.data.cols;
+        let rows = x.shape[0];
+        let cols = x.shape[1];
         let mut out = Matrix::zeros(rows, cols);
         for r in 0..rows {
             for c in 0..cols {
                 let idx = r * cols + c;
-                let x_hat = (x.data.data[idx] - self.running_mean[c])
+                let x_hat = (x.data[idx] - self.running_mean[c])
                     / (self.running_var[c] + self.eps).sqrt();
                 out.data[idx] = self.gamma.w[c] * x_hat + self.beta.w[c];
             }
@@ -260,25 +260,25 @@ impl LayerNorm {
     }
 
     pub fn forward(&self, x: &Tensor) -> Tensor {
-        let rows = x.data.rows;
-        let cols = x.data.cols;
+        let rows = x.shape[0];
+        let cols = x.shape[1];
         let mut out = Matrix::zeros(rows, cols);
         for r in 0..rows {
             let mut mean = 0.0;
             for c in 0..cols {
-                mean += x.data.data[r * cols + c];
+                mean += x.data[r * cols + c];
             }
             mean /= cols as f32;
             let mut var = 0.0;
             for c in 0..cols {
-                let v = x.data.data[r * cols + c] - mean;
+                let v = x.data[r * cols + c] - mean;
                 var += v * v;
             }
             var /= cols as f32;
             let inv_std = 1.0 / (var + self.eps).sqrt();
             for c in 0..cols {
                 let idx = r * cols + c;
-                let x_hat = (x.data.data[idx] - mean) * inv_std;
+                let x_hat = (x.data[idx] - mean) * inv_std;
                 out.data[idx] = self.gamma.w[c] * x_hat + self.beta.w[c];
             }
         }

--- a/src/layers/pooling.rs
+++ b/src/layers/pooling.rs
@@ -144,7 +144,8 @@ impl MaxPool2d {
     }
 
     fn forward_internal(&self, x: &Tensor) -> Tensor {
-        let (out, _idx) = max_pool2d(&x.data, self.kernel, self.stride);
+        let x_m = Matrix::from_vec(x.shape[0], x.shape[1], x.data.clone());
+        let (out, _idx) = max_pool2d(&x_m, self.kernel, self.stride);
         Tensor::from_matrix(out)
     }
 

--- a/src/layers/relu.rs
+++ b/src/layers/relu.rs
@@ -5,7 +5,7 @@ use super::linear::LinearT;
 
 /// Apply ReLU activation in place on a tensor.
 pub fn forward_tensor(t: &mut Tensor) {
-    for v in t.data.data.iter_mut() {
+    for v in t.data.iter_mut() {
         if *v < 0.0 {
             *v = 0.0;
         }

--- a/src/layers/rnn.rs
+++ b/src/layers/rnn.rs
@@ -80,17 +80,21 @@ impl LSTM {
     }
 
     fn step(&self, x_t: &Matrix, h_prev: &Matrix, c_prev: &Matrix) -> (Matrix, Matrix, Matrix, Matrix, Matrix, Matrix) {
-        let mut i = Matrix::matmul(x_t, &self.w_ii.w.data)
-            .add(&Matrix::matmul(h_prev, &self.w_hi.w.data));
+        let w_ii = Matrix::from_vec(self.w_ii.w.shape[0], self.w_ii.w.shape[1], self.w_ii.w.data.clone());
+        let w_hi = Matrix::from_vec(self.w_hi.w.shape[0], self.w_hi.w.shape[1], self.w_hi.w.data.clone());
+        let mut i = Matrix::matmul(x_t, &w_ii).add(&Matrix::matmul(h_prev, &w_hi));
         sigmoid::forward_matrix(&mut i);
-        let mut f = Matrix::matmul(x_t, &self.w_if.w.data)
-            .add(&Matrix::matmul(h_prev, &self.w_hf.w.data));
+        let w_if = Matrix::from_vec(self.w_if.w.shape[0], self.w_if.w.shape[1], self.w_if.w.data.clone());
+        let w_hf = Matrix::from_vec(self.w_hf.w.shape[0], self.w_hf.w.shape[1], self.w_hf.w.data.clone());
+        let mut f = Matrix::matmul(x_t, &w_if).add(&Matrix::matmul(h_prev, &w_hf));
         sigmoid::forward_matrix(&mut f);
-        let mut o = Matrix::matmul(x_t, &self.w_io.w.data)
-            .add(&Matrix::matmul(h_prev, &self.w_ho.w.data));
+        let w_io = Matrix::from_vec(self.w_io.w.shape[0], self.w_io.w.shape[1], self.w_io.w.data.clone());
+        let w_ho = Matrix::from_vec(self.w_ho.w.shape[0], self.w_ho.w.shape[1], self.w_ho.w.data.clone());
+        let mut o = Matrix::matmul(x_t, &w_io).add(&Matrix::matmul(h_prev, &w_ho));
         sigmoid::forward_matrix(&mut o);
-        let mut g = Matrix::matmul(x_t, &self.w_ig.w.data)
-            .add(&Matrix::matmul(h_prev, &self.w_hg.w.data));
+        let w_ig = Matrix::from_vec(self.w_ig.w.shape[0], self.w_ig.w.shape[1], self.w_ig.w.data.clone());
+        let w_hg = Matrix::from_vec(self.w_hg.w.shape[0], self.w_hg.w.shape[1], self.w_hg.w.data.clone());
+        let mut g = Matrix::matmul(x_t, &w_ig).add(&Matrix::matmul(h_prev, &w_hg));
         tanh::forward_matrix(&mut g);
         let c = elem_mul(&f, c_prev).add(&elem_mul(&i, &g));
         let mut h = c.clone();
@@ -294,15 +298,18 @@ impl GRU {
     }
 
     fn step(&self, x_t: &Matrix, h_prev: &Matrix) -> (Matrix, Matrix, Matrix, Matrix) {
-        let mut r = Matrix::matmul(x_t, &self.w_ir.w.data)
-            .add(&Matrix::matmul(h_prev, &self.w_hr.w.data));
+        let w_ir = Matrix::from_vec(self.w_ir.w.shape[0], self.w_ir.w.shape[1], self.w_ir.w.data.clone());
+        let w_hr = Matrix::from_vec(self.w_hr.w.shape[0], self.w_hr.w.shape[1], self.w_hr.w.data.clone());
+        let mut r = Matrix::matmul(x_t, &w_ir).add(&Matrix::matmul(h_prev, &w_hr));
         sigmoid::forward_matrix(&mut r);
-        let mut z = Matrix::matmul(x_t, &self.w_iz.w.data)
-            .add(&Matrix::matmul(h_prev, &self.w_hz.w.data));
+        let w_iz = Matrix::from_vec(self.w_iz.w.shape[0], self.w_iz.w.shape[1], self.w_iz.w.data.clone());
+        let w_hz = Matrix::from_vec(self.w_hz.w.shape[0], self.w_hz.w.shape[1], self.w_hz.w.data.clone());
+        let mut z = Matrix::matmul(x_t, &w_iz).add(&Matrix::matmul(h_prev, &w_hz));
         sigmoid::forward_matrix(&mut z);
         let rh = elem_mul(&r, h_prev);
-        let mut n = Matrix::matmul(x_t, &self.w_in.w.data)
-            .add(&Matrix::matmul(&rh, &self.w_hn.w.data));
+        let w_in = Matrix::from_vec(self.w_in.w.shape[0], self.w_in.w.shape[1], self.w_in.w.data.clone());
+        let w_hn = Matrix::from_vec(self.w_hn.w.shape[0], self.w_hn.w.shape[1], self.w_hn.w.data.clone());
+        let mut n = Matrix::matmul(x_t, &w_in).add(&Matrix::matmul(&rh, &w_hn));
         tanh::forward_matrix(&mut n);
         let one_minus_z = elem_sub_from_one(&z);
         let h = elem_mul(&z, h_prev).add(&elem_mul(&one_minus_z, &n));

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -169,8 +169,8 @@ pub fn load_model(
         serde_json::from_str(&txt).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     if !model.encoder_embedding.is_empty() {
         let mut params = encoder.embedding.parameters();
-        let exp_rows = params[0].w.data.rows;
-        let exp_cols = params[0].w.data.cols;
+        let exp_rows = params[0].w.shape[0];
+        let exp_cols = params[0].w.shape[1];
         let loaded = vec2_to_matrix(&model.encoder_embedding);
         let mut mat = Matrix::zeros(exp_rows, exp_cols);
         for r in 0..loaded.rows.min(exp_rows) {
@@ -182,8 +182,8 @@ pub fn load_model(
     }
     if !model.decoder_embedding.is_empty() {
         let mut params = decoder.embedding.parameters();
-        let exp_rows = params[0].w.data.rows;
-        let exp_cols = params[0].w.data.cols;
+        let exp_rows = params[0].w.shape[0];
+        let exp_cols = params[0].w.shape[1];
         let loaded = vec2_to_matrix(&model.decoder_embedding);
         let mut mat = Matrix::zeros(exp_rows, exp_cols);
         for r in 0..loaded.rows.min(exp_rows) {
@@ -457,17 +457,17 @@ pub fn load_transformer_from_hf(
         )
         .into());
     }
-    if cfg.hidden_size != model.embedding.table.w.data.cols {
+    if cfg.hidden_size != model.embedding.table.w.shape[1] {
         return Err(format!(
             "hidden size mismatch: config {} vs model {}",
-            cfg.hidden_size, model.embedding.table.w.data.cols
+            cfg.hidden_size, model.embedding.table.w.shape[1]
         )
         .into());
     }
-    if cfg.vocab_size != model.embedding.table.w.data.rows {
+    if cfg.vocab_size != model.embedding.table.w.shape[0] {
         return Err(format!(
             "vocab size mismatch: config {} vs model {}",
-            cfg.vocab_size, model.embedding.table.w.data.rows
+            cfg.vocab_size, model.embedding.table.w.shape[0]
         )
         .into());
     }
@@ -478,10 +478,10 @@ pub fn load_transformer_from_hf(
         )
         .into());
     }
-    if cfg.intermediate_size != model.layers[0].ff.w1.w.data.cols {
+    if cfg.intermediate_size != model.layers[0].ff.w1.w.shape[1] {
         return Err(format!(
             "feed-forward size mismatch: config {} vs model {}",
-            cfg.intermediate_size, model.layers[0].ff.w1.w.data.cols
+            cfg.intermediate_size, model.layers[0].ff.w1.w.shape[1]
         )
         .into());
     }
@@ -570,10 +570,10 @@ fn load_embedding(
     }
     let rows = shape[0];
     let cols = shape[1];
-    if lin.w.data.rows != rows || lin.w.data.cols != cols {
+    if lin.w.shape[0] != rows || lin.w.shape[1] != cols {
         return Err(format!(
             "shape mismatch for {name}: expected {}x{}, got {}x{}",
-            lin.w.data.rows, lin.w.data.cols, rows, cols
+            lin.w.shape[0], lin.w.shape[1], rows, cols
         )
         .into());
     }
@@ -596,10 +596,10 @@ fn load_linear(
     }
     let out_dim = shape[0];
     let in_dim = shape[1];
-    if lin.w.data.rows != in_dim || lin.w.data.cols != out_dim {
+    if lin.w.shape[0] != in_dim || lin.w.shape[1] != out_dim {
         return Err(format!(
             "shape mismatch for {name}: expected {}x{}, got {}x{}",
-            lin.w.data.rows, lin.w.data.cols, in_dim, out_dim
+            lin.w.shape[0], lin.w.shape[1], in_dim, out_dim
         )
         .into());
     }

--- a/tests/hf_loading.rs
+++ b/tests/hf_loading.rs
@@ -26,23 +26,23 @@ fn hf_loading() {
         .expect("failed to load transformer weights");
 
     // Check embedding dimensions
-    assert_eq!(enc.embedding.table.w.data.rows, 1000);
-    assert_eq!(enc.embedding.table.w.data.cols, 32);
+    assert_eq!(enc.embedding.table.w.shape[0], 1000);
+    assert_eq!(enc.embedding.table.w.shape[1], 32);
 
     // Check layer parameters
     for layer in &enc.layers {
-        assert_eq!(layer.attn.wq.w.data.rows, 32);
-        assert_eq!(layer.attn.wq.w.data.cols, 32);
-        assert_eq!(layer.attn.wk.w.data.rows, 32);
-        assert_eq!(layer.attn.wk.w.data.cols, 32);
-        assert_eq!(layer.attn.wv.w.data.rows, 32);
-        assert_eq!(layer.attn.wv.w.data.cols, 32);
-        assert_eq!(layer.attn.wo.w.data.rows, 32);
-        assert_eq!(layer.attn.wo.w.data.cols, 32);
-        assert_eq!(layer.ff.w1.w.data.rows, 32);
-        assert_eq!(layer.ff.w1.w.data.cols, 64);
-        assert_eq!(layer.ff.w2.w.data.rows, 64);
-        assert_eq!(layer.ff.w2.w.data.cols, 32);
+        assert_eq!(layer.attn.wq.w.shape[0], 32);
+        assert_eq!(layer.attn.wq.w.shape[1], 32);
+        assert_eq!(layer.attn.wk.w.shape[0], 32);
+        assert_eq!(layer.attn.wk.w.shape[1], 32);
+        assert_eq!(layer.attn.wv.w.shape[0], 32);
+        assert_eq!(layer.attn.wv.w.shape[1], 32);
+        assert_eq!(layer.attn.wo.w.shape[0], 32);
+        assert_eq!(layer.attn.wo.w.shape[1], 32);
+        assert_eq!(layer.ff.w1.w.shape[0], 32);
+        assert_eq!(layer.ff.w1.w.shape[1], 64);
+        assert_eq!(layer.ff.w2.w.shape[0], 64);
+        assert_eq!(layer.ff.w2.w.shape[1], 32);
     }
 
     // Prepare one-hot inputs for token sequence [1,2,3,4]
@@ -61,7 +61,8 @@ fn hf_loading() {
 
     for i in 0..tokens.len() {
         for j in 0..32 {
-            let diff = (out.data.get(i, j) - reference[i][j]).abs();
+            let idx = i * 32 + j;
+            let diff = (out.data[idx] - reference[i][j]).abs();
             assert!(diff < 1e-4, "mismatch at ({},{}) diff {}", i, j, diff);
         }
     }

--- a/tests/moe_training.rs
+++ b/tests/moe_training.rs
@@ -18,7 +18,7 @@ fn moe_layer_updates_parameters() {
     let mut params = moe.parameters();
     let before: Vec<Vec<f32>> = params
         .iter()
-        .map(|p| p.w.data.data.clone())
+        .map(|p| p.w.data.clone())
         .collect();
     for p in params.iter_mut() {
         p.sgd_step(0.1, 0.0);
@@ -27,7 +27,6 @@ fn moe_layer_updates_parameters() {
     for (after, b) in params_after.iter().zip(before.iter()) {
         let changed = after
             .w
-            .data
             .data
             .iter()
             .zip(b.iter())


### PR DESCRIPTION
## Summary
- Convert tensor-based layers to use `Matrix` for row/column operations
- Update BatchNorm and others to index via tensor shapes
- Modernize examples and tests to work with new tensor layout

## Testing
- `cargo test` *(fails: failed to fetch model weights)*

------
https://chatgpt.com/codex/tasks/task_e_68b2889bbb98832f9f161627472d2853