### PR TITLE
feat: add configurable logging flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -315,8 +316,22 @@ version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -918,6 +933,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1915,7 +1936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes 0.5.6",
- "heck",
+ "heck 0.3.3",
  "itertools 0.8.2",
  "log",
  "multimap",
@@ -2493,6 +2514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +2916,7 @@ dependencies = [
  "bincode",
  "cc",
  "cifar_10_loader",
+ "clap",
  "criterion",
  "csv",
  "cust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cifar_10_loader = "0.2"
 libc = "0.2"
 log = "0.4"
 env_logger = "0.11"
+clap = { version = "4", features = ["derive"] }
 rayon = "1.8"
 toml = "0.8"
 csv = "1"

--- a/README.md
+++ b/README.md
@@ -74,14 +74,17 @@ When predicting with `--moe`, a corresponding `moe.json` file is read to load th
 
 ### Logging
 
-All binaries use the [`log`](https://crates.io/crates/log) facade with `env_logger` for output.
-Set the desired level with the `RUST_LOG` environment variable:
+All binaries use the [`log`](https://crates.io/crates/log) facade with
+`env_logger` for output. Set the desired verbosity with the new
+`--log-level` flag or silence logs with `--quiet`:
 
 ```bash
-RUST_LOG=info ./run.sh train-noprop
+./run.sh train-noprop --log-level debug
+./run.sh train-noprop --quiet
 ```
 
-Levels such as `debug`, `warn` or `error` are also supported.
+The `RUST_LOG` environment variable is still honoured when the flag is
+omitted.
 
 ### AutoML
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,13 +1,12 @@
-use std::{env, process::Command};
+use std::process::Command;
 use vanillanoprop::{data, predict};
 
 mod common;
 
 fn main() {
-    env_logger::init();
-    let args: Vec<String> = env::args().collect();
+    let args = common::init_logging();
     if args.len() < 2 {
-        eprintln!("Usage: {} <mode>", args[0]);
+        eprintln!("Usage: {} [--log-level <LEVEL>|--quiet] <mode>", args[0]);
         eprintln!(
             "Modes: predict | predict-rnn | download | train-backprop | train-elmo | train-noprop | train-lcm | train-rnn | train-treepo | automl",
         );

--- a/src/bin/sample_vae.rs
+++ b/src/bin/sample_vae.rs
@@ -1,12 +1,13 @@
-use std::env;
 use vanillanoprop::math::Matrix;
 use vanillanoprop::rng::rng_from_env;
 use vanillanoprop::weights::load_vae;
 use rand_distr::{Distribution, StandardNormal};
 
+mod common;
+
 fn main() {
-    env_logger::init();
-    let path = env::args().nth(1).unwrap_or_else(|| "vae.json".to_string());
+    let args = common::init_logging();
+    let path = args.into_iter().nth(1).unwrap_or_else(|| "vae.json".to_string());
     let input_dim = 28 * 28;
     let hidden_dim = 400;
     let latent_dim = 20;
@@ -18,5 +19,5 @@ fn main() {
         z.set(0, i, e);
     }
     let sample = vae.decode(&z);
-    println!("sample first values: {:?}", &sample.data[..10.min(sample.data.len())]);
+    log::info!("sample first values: {:?}", &sample.data[..10.min(sample.data.len())]);
 }

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use indicatif::ProgressBar;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -25,7 +23,7 @@ use vanillanoprop::weights::{
 mod common;
 
 fn main() {
-    env_logger::init();
+    let args = common::init_logging();
     let (
         model,
         opt,
@@ -43,7 +41,7 @@ fn main() {
         auto_ml,
         config,
         _,
-    ) = common::parse_cli(env::args().skip(1));
+    ) = common::parse_cli(args.into_iter().skip(1));
 
     let _ft = fine_tune.map(|model_id| {
         vanillanoprop::fine_tune::run(&model_id, freeze_layers, |_, _| Ok(()))
@@ -57,7 +55,7 @@ fn main() {
             let mut rng = rng_from_env();
             let eval = |_cfg: Config| rand::random::<f32>();
             let (_best_cfg, best_score) = random_search(&space, 10, eval, &mut rng, &mut logger);
-            println!("AutoML best score: {best_score:.4}");
+            log::info!("AutoML best score: {best_score:.4}");
         }
         return;
     }
@@ -227,7 +225,6 @@ fn run(
             last_loss = batch_loss;
             f1_sum += batch_f1;
             sample_cnt += bsz;
-            println!("loss {batch_loss:.4} f1 {batch_f1_avg:.4}");
             if let Some(l) = &mut logger {
                 l.log(&MetricRecord {
                     epoch,
@@ -241,6 +238,7 @@ fn run(
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
+        log::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -255,7 +253,7 @@ fn run(
 
         let mut should_save = false;
         if avg_f1 > best_f1 {
-            println!("Checkpoint saved at epoch {epoch}: avg F1 improved to {avg_f1:.4}");
+            log::info!("Checkpoint saved at epoch {epoch}: avg F1 improved to {avg_f1:.4}");
             best_f1 = avg_f1;
             should_save = true;
         }
@@ -279,20 +277,20 @@ fn run(
             };
             let path = format!("{}/epoch_{}.json", ckpt_dir, epoch);
             if let Err(e) = save_checkpoint(&path, &cp) {
-                eprintln!("Failed to save checkpoint: {e}");
+                log::error!("Failed to save checkpoint: {e}");
             }
         }
     }
     pb.finish_with_message("training done");
 
-    println!("Total matrix ops: {}", math::matrix_ops_count());
+    log::info!("Total matrix ops: {}", math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    println!(
+    log::info!(
         "Max memory usage: {:.2} MB",
         peak as f64 / (1024.0 * 1024.0)
     );
 
     if let Err(e) = save_model(&format!("{}/model.json", ckpt_dir), &mut encoder, None) {
-        eprintln!("Failed to save model: {e}");
+        log::error!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_rnn.rs
+++ b/src/bin/train_rnn.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use indicatif::ProgressBar;
 use vanillanoprop::config::Config;
 use vanillanoprop::data::{DataLoader, Mnist};
@@ -15,7 +13,7 @@ use vanillanoprop::weights::save_rnn;
 mod common;
 
 fn main() {
-    env_logger::init();
+    let args = common::init_logging();
     let (
         _model,
         _opt,
@@ -33,7 +31,7 @@ fn main() {
         _auto_ml,
         config,
         _,
-    ) = common::parse_cli(env::args().skip(1));
+    ) = common::parse_cli(args.into_iter().skip(1));
 
     let ft = fine_tune.map(|model_id| {
         vanillanoprop::fine_tune::run(&model_id, freeze_layers, |_, _| Ok(()))
@@ -105,7 +103,6 @@ fn run(
                 let mut raw: Vec<&mut LinearT> = params.into_iter().map(|(_, p)| p).collect();
                 trainer.fit(&mut raw);
             }
-            println!("loss {batch_loss:.4} f1 {batch_f1:.4}");
             if let Some(l) = &mut logger {
                 l.log(&MetricRecord {
                     epoch,
@@ -119,6 +116,7 @@ fn run(
             step += 1;
         }
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
+        log::info!("epoch {epoch} loss {last_loss:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -134,6 +132,6 @@ fn run(
     pb.finish_with_message("training done");
 
     if let Err(e) = save_rnn("rnn.json", &mut rnn) {
-        eprintln!("Failed to save model: {e}");
+        log::error!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_treepo.rs
+++ b/src/bin/train_treepo.rs
@@ -2,6 +2,8 @@ use rand::Rng;
 use vanillanoprop::rl::treepo::TreeNode;
 use vanillanoprop::rl::{Env, TreePoAgent};
 
+mod common;
+
 struct LineWorld {
     position: i32,
     goal: i32,
@@ -32,7 +34,7 @@ impl Env for LineWorld {
 }
 
 fn main() {
-    env_logger::init();
+    let _ = common::init_logging();
     let env = LineWorld {
         position: 0,
         goal: 5,
@@ -67,6 +69,6 @@ fn main() {
                 break;
             }
         }
-        println!("Episode {} complete", episode + 1);
+        log::info!("Episode {} complete", episode + 1);
     }
 }

--- a/src/bin/train_vae.rs
+++ b/src/bin/train_vae.rs
@@ -5,8 +5,10 @@ use vanillanoprop::models::VAE;
 use vanillanoprop::optim::{Adam, MseLoss};
 use vanillanoprop::weights::save_vae;
 
+mod common;
+
 fn main() {
-    env_logger::init();
+    let _ = common::init_logging();
     let pairs: Vec<(Vec<u8>, usize)> = DataLoader::<Mnist>::new(1, true, None)
         .take(10)
         .flat_map(|b| b.iter().cloned())
@@ -32,10 +34,10 @@ fn main() {
             trainer.fit(&mut params);
             total += recon_loss + kl_loss;
         }
-        println!("epoch {epoch} loss {:.4}", total / pairs.len() as f32);
+        log::info!("epoch {epoch} loss {:.4}", total / pairs.len() as f32);
     }
 
     if let Err(e) = save_vae("vae.json", &vae) {
-        eprintln!("failed to save model: {e}");
+        log::error!("failed to save model: {e}");
     }
 }


### PR DESCRIPTION
## Summary
- add global `--log-level`/`--quiet` flags for all binaries
- route progress output through the `log` facade and throttle to epoch summaries
- document new logging options

## Testing
- `cargo test` *(fails: failed to fetch model weights)*

------
https://chatgpt.com/codex/tasks/task_e_68b29308b464832f840fa1a6d0a56750