### PR TITLE
Add example config files for training variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,17 +157,23 @@ epochs = 10
 batch_size = 8
 ```
 
-Run a training binary with a configuration file:
+Example configuration files for each training variant are included in the
+repository root. Run a training binary with one of them via `--config`:
 
 ```bash
-./run.sh train-noprop --config config.toml
+./run.sh train-backprop --config backprop_config.toml
+./run.sh train-elmo --config elmo_config.toml
+./run.sh train-noprop --config noprop_config.toml
 ./run.sh train-lcm --config lcm_config.toml
+./run.sh train-resnet --config resnet_config.toml
+./run.sh train-rnn --config rnn_config.toml
+./run.sh train-treepo --config treepo_config.toml
 ```
 
 Or override specific settings from the command line:
 
 ```bash
-./run.sh train-noprop --config config.toml --epochs 20 --batch-size 16
+./run.sh train-noprop --config noprop_config.toml --epochs 20 --batch-size 16
 ```
 
 ## Examples

--- a/backprop_config.toml
+++ b/backprop_config.toml
@@ -1,0 +1,5 @@
+# Example configuration for backprop training
+epochs = 10
+batch_size = 32
+dataset = "mnist"
+learning_rate = [0.001]

--- a/elmo_config.toml
+++ b/elmo_config.toml
@@ -1,0 +1,5 @@
+# Example configuration for ELMo training
+epochs = 8
+batch_size = 16
+dataset = "mnist"
+learning_rate = [0.005]

--- a/noprop_config.toml
+++ b/noprop_config.toml
@@ -1,0 +1,5 @@
+# Example configuration for NoProp training
+epochs = 5
+batch_size = 8
+dataset = "mnist"
+learning_rate = [0.01]

--- a/resnet_config.toml
+++ b/resnet_config.toml
@@ -1,0 +1,5 @@
+# Example configuration for ResNet training
+epochs = 15
+batch_size = 64
+dataset = "mnist"
+learning_rate = [0.01]

--- a/rnn_config.toml
+++ b/rnn_config.toml
@@ -1,0 +1,5 @@
+# Example configuration for RNN training
+epochs = 20
+batch_size = 32
+dataset = "mnist"
+learning_rate = [0.001]


### PR DESCRIPTION
## Summary
- provide sample configuration files for backprop, ELMo, NoProp, ResNet, and RNN training
- document available config files in README

## Testing
- `cargo test` *(fails: failed to fetch model weights)*
