### PR TITLE
Use here-doc in run.sh usage

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 {download|predict|predict-rnn|train-backprop|train-elmo|train-noprop|train-lcm|train-resnet|train-rnn|train-treepo} [model] [opt] [--moe] [--num-experts N] [--resume FILE] [--export-onnx FILE]" >&2
+  cat >&2 <<'USAGE'
+Usage: $0 {download|predict|predict-rnn|train-backprop|train-elmo|train-noprop|train-lcm|train-resnet|train-rnn|train-treepo} [model] [opt] [--moe] [--num-experts N] [--resume FILE] [--export-onnx FILE]
+USAGE
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- streamline run.sh usage message with a here-doc

## Testing
- `bash -n run.sh`
- `cargo test` *(fails: failed to fetch model weights: RequestError(Transport(Transport { kind: ProxyConnect, message: None, url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("huggingface.co")), port: None, path: "/hf-internal-testing/tiny-random-bert/resolve/main/model.safetensors", query: None, fragment: None }), source: None })))*
