### PR TITLE
Fix logging flag parser to accept training subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -316,22 +315,8 @@ version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -933,12 +918,6 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1936,7 +1915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes 0.5.6",
- "heck 0.3.3",
+ "heck",
  "itertools 0.8.2",
  "log",
  "multimap",
@@ -2514,12 +2493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,7 +2889,6 @@ dependencies = [
  "bincode",
  "cc",
  "cifar_10_loader",
- "clap",
  "criterion",
  "csv",
  "cust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ cifar_10_loader = "0.2"
 libc = "0.2"
 log = "0.4"
 env_logger = "0.11"
-clap = { version = "4", features = ["derive"] }
 rayon = "1.8"
 toml = "0.8"
 csv = "1"


### PR DESCRIPTION
## Summary
- parse --log-level and --quiet manually so other CLI args are accepted
- remove unused clap dependency

## Testing
- `cargo test --lib`
- `cargo run --bin main -- train-noprop --config noprop_config.toml --epochs 0 --quiet`

