### PR TITLE
docs: clarify run commands and prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ vanillanoprop is tested on Linux, macOS and Windows. Memory tracking utilities
 such as `memory::peak_memory_bytes` report actual values on these platforms and
 return `0` elsewhere.
 
+## Prerequisites
+
+Examples that train on datasets like MNIST download them on first use and
+require an active internet connection. Training binaries read configuration
+files such as `noprop_config.toml` or `treepo_config.toml` from the repository
+root.
+
 ## Installation
 
 Clone the repository and build the project using cargo:
@@ -28,7 +35,9 @@ cd vanillanoprop
 cargo build
 ```
 
-The `run.sh` script exposes a convenience CLI that lists available commands.
+The `run.sh` script exposes a convenience CLI for training binaries. Standalone
+examples under `examples/` are run with `cargo run --example <NAME>`. List the
+available training commands with:
 
 ```bash
 ./run.sh
@@ -58,7 +67,8 @@ let c = Matrix::matmul_with(&a, &b, &dev);
 
 ## Usage
 
-Typical training commands:
+Use `./run.sh` for training pipelines and `cargo run --example <NAME>` for
+standalone demos. Typical training commands:
 
 ```bash
 ./run.sh train-noprop cnn --moe --num-experts 4
@@ -179,7 +189,9 @@ Pass `--config <FILE>` to load a different file or override specific settings fr
 
 ## Examples
 
-The `examples` directory contains small programs that showcase core features of the framework.
+Run standalone demos with `cargo run --example <NAME>`; use `./run.sh` for the
+training binaries. The `examples` directory contains small programs that
+showcase core features of the framework.
 
 - **Mixture of Experts** – `cargo run --example mixture_of_experts` ([walkthrough](docs/examples/mixture_of_experts.md))
   Builds a tiny mixture‑of‑experts network and prints gating probabilities.

--- a/docs/examples/autoencoder.md
+++ b/docs/examples/autoencoder.md
@@ -1,7 +1,12 @@
 # Autoencoder Example
 
 Demonstrates a tiny variational autoencoder that reconstructs MNIST
-images. Launch it with:
+images.
+
+**Prerequisites:** downloads the MNIST dataset on first run.
+
+**Demo command:** (use `cargo run --example`; training binaries use
+`./run.sh`)
 
 ```bash
 cargo run --example autoencoder

--- a/docs/examples/automl.md
+++ b/docs/examples/automl.md
@@ -1,7 +1,12 @@
 # AutoML Example
 
 The training binaries support a simple random search over hyperparameters.
-Enable it via the `--auto-ml` flag:
+
+**Prerequisites:** a configuration file listing hyperparameters (e.g.,
+`config.toml`).
+
+**Training command:** (use `./run.sh`; standalone demos are run with
+`cargo run --example`)
 
 ```bash
 ./run.sh train-noprop --auto-ml --config config.toml

--- a/docs/examples/data_loader.md
+++ b/docs/examples/data_loader.md
@@ -4,6 +4,12 @@ The `DataLoader` trait and struct provide a unified way to work with
 datasets that fit in memory.  It supports batching, optional shuffling
 and an optional transform hook for preprocessing or data augmentation.
 
+**Prerequisites:** datasets such as MNIST or CIFAR10; they are downloaded on
+first use.
+
+This page shows library snippets only. To see a runnable demo, execute
+`cargo run --example mnist_cnn`. Training binaries are invoked with `./run.sh`.
+
 ```rust
 use vanillanoprop::data::{DataLoader, Mnist};
 

--- a/docs/examples/fine_tuning.md
+++ b/docs/examples/fine_tuning.md
@@ -1,7 +1,11 @@
 # Fine-tuning Example
 
 Initialise a model from the Hugging Face Hub and continue training while
-optionally freezing specific layers:
+optionally freezing specific layers.
+
+**Prerequisites:** internet access to fetch the specified checkpoint.
+
+**Training command:** (use `./run.sh`; demos run with `cargo run --example`)
 
 ```bash
 ./run.sh train-backprop --fine-tune bert-base-uncased --freeze-layers 0,1,2

--- a/docs/examples/hf_transformer.md
+++ b/docs/examples/hf_transformer.md
@@ -1,7 +1,11 @@
 # Hugging Face Transformer Example
 
 Shows how to fetch pretrained weights from the Hugging Face Hub and run a
-dummy inference. Execute:
+dummy inference.
+
+**Prerequisites:** internet access to download the model.
+
+**Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)
 
 ```bash
 cargo run --example hf_transformer

--- a/docs/examples/load_config.md
+++ b/docs/examples/load_config.md
@@ -1,7 +1,12 @@
 # Loading Configuration Example
 
 This example reads training parameters from a `TOML` file and falls back
-to defaults when the file is missing. Execute it with:
+to defaults when the file is missing.
+
+**Prerequisites:** `lcm_config.toml` in the repository root.
+
+**Demo command:** (use `cargo run --example`; training binaries run with
+`./run.sh`)
 
 ```bash
 cargo run --example load_config

--- a/docs/examples/mixture_of_experts.md
+++ b/docs/examples/mixture_of_experts.md
@@ -1,7 +1,12 @@
 # Mixture of Experts Example
 
 This walkthrough builds a tiny mixture-of-experts layer and prints the
-routing probabilities for each input. Run it with cargo:
+routing probabilities for each input.
+
+**Prerequisites:** none beyond the standard Rust toolchain.
+
+**Demo command:** (use `cargo run --example`; training binaries use
+`./run.sh`)
 
 ```bash
 cargo run --example mixture_of_experts

--- a/docs/examples/mnist_cnn.md
+++ b/docs/examples/mnist_cnn.md
@@ -1,6 +1,10 @@
 # MNIST CNN Example
 
-Trains a small convolutional network on the MNIST digits dataset. Run:
+Trains a small convolutional network on the MNIST digits dataset.
+
+**Prerequisites:** downloads the MNIST dataset on first run.
+
+**Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)
 
 ```bash
 cargo run --example mnist_cnn

--- a/docs/examples/onnx_export.md
+++ b/docs/examples/onnx_export.md
@@ -1,7 +1,12 @@
 # ONNX Export Example
 
 Training binaries can export weights to the ONNX format by providing an
-output path:
+output path.
+
+**Prerequisites:** choose an output file for the exported model.
+
+**Training command:** (use `./run.sh`; demos are run with
+`cargo run --example`)
 
 ```bash
 ./run.sh train-noprop --export-onnx model.onnx

--- a/docs/examples/text_rnn.md
+++ b/docs/examples/text_rnn.md
@@ -1,7 +1,11 @@
 # Text RNN Example
 
-This walkthrough builds a simple LSTM for toy text classification. Invoke
-it with:
+This walkthrough builds a simple LSTM for toy text classification.
+
+**Prerequisites:** uses a small in-memory toy dataset.
+
+**Demo command:** (use `cargo run --example`; training binaries use
+`./run.sh`)
 
 ```bash
 cargo run --example text_rnn

--- a/docs/examples/treepo.md
+++ b/docs/examples/treepo.md
@@ -1,7 +1,11 @@
 # TreePO Example
 
 Tree Policy Optimisation (TreePO) combines planning with policy
-optimisation. Start a training run with:
+optimisation.
+
+**Prerequisites:** `treepo_config.toml` in the repository root.
+
+**Training command:** (use `./run.sh`; demos run with `cargo run --example`)
 
 ```bash
 ./run.sh train-treepo --config treepo_config.toml


### PR DESCRIPTION
## Summary
- document when to use `./run.sh` versus `cargo run --example`
- add prerequisites/environment notes for README and example pages
- label command blocks by purpose for consistent documentation

## Testing
- `cargo test` *(fails: failed to fetch model weights)*
