### PR TITLE
Add documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vanillanoprop is a vanilla machine learning library implementation.
 - Configuration via TOML or JSON files with command‑line overrides.
 - Collection of examples demonstrating core components.
 
-A more thorough introduction with additional examples can be found in [docs/introduction.md](docs/introduction.md).
+A more thorough introduction with additional examples can be found in the [documentation index](docs/README.md).
 
 ## Supported operating systems
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Documentation
+
+This directory collects guides and examples for vanillanoprop.
+
+- [Introduction](introduction.md) – High-level overview of the library and its components.
+
+## Examples
+
+Each walkthrough demonstrates a specific feature:
+
+- [Autoencoder](examples/autoencoder.md)
+- [Automl](examples/automl.md)
+- [Data loader](examples/data_loader.md)
+- [Fine tuning](examples/fine_tuning.md)
+- [Hugging Face Transformer](examples/hf_transformer.md)
+- [Load configuration](examples/load_config.md)
+- [Mixture of Experts](examples/mixture_of_experts.md)
+- [MNIST CNN](examples/mnist_cnn.md)
+- [ONNX export](examples/onnx_export.md)
+- [Text RNN](examples/text_rnn.md)
+- [Tree policy optimization](examples/treepo.md)
+


### PR DESCRIPTION
## Summary
- add docs/README with an overview and links to all example docs
- point the top-level README to the new documentation index

## Testing
- `cargo test` *(fails: test `hf_loading`)*
