### PR TITLE
Reuse DataLoader across epochs

### DIFF
--- a/src/bin/compare.rs
+++ b/src/bin/compare.rs
@@ -21,12 +21,13 @@ fn train_backprop(epochs: usize) -> (f32, usize, usize, u64) {
     let pb = ProgressBar::new(epochs as u64);
     let mut best_f1 = f32::NEG_INFINITY;
 
+    let mut loader = DataLoader::<Mnist>::new(4, false, None);
     for epoch in 0..epochs {
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
-
-        for batch in DataLoader::<Mnist>::new(4, true, None) {
+        loader.reset(true);
+        for batch in loader.by_ref() {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
 
@@ -91,12 +92,13 @@ fn train_noprop(epochs: usize) -> (f32, usize, usize, u64) {
     let pb = ProgressBar::new(epochs as u64);
     let mut best_f1 = f32::NEG_INFINITY;
 
+    let mut loader = DataLoader::<Mnist>::new(4, false, None);
     for epoch in 0..epochs {
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
-
-        for batch in DataLoader::<Mnist>::new(4, true, None) {
+        loader.reset(true);
+        for batch in loader.by_ref() {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
 

--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -139,11 +139,13 @@ fn run(
     let pb = ProgressBar::new(epochs as u64);
     let mut best_f1 = f32::NEG_INFINITY;
     let mut step = 0usize;
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
     for epoch in 0..epochs {
+        loader.reset(true);
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             encoder.zero_grad();
             decoder.zero_grad();
             let mut batch_loss = 0.0f32;

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -94,11 +94,13 @@ fn run(
     let pb = ProgressBar::new(epochs as u64);
     let mut best_f1 = f32::NEG_INFINITY;
     let mut step = 0usize;
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
     for epoch in 0..epochs {
+        loader.reset(true);
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             encoder.zero_grad();
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;

--- a/src/bin/train_lcm.rs
+++ b/src/bin/train_lcm.rs
@@ -41,11 +41,13 @@ fn run(config: &Config) {
     let evaluator = Model::new();
 
     let pb = ProgressBar::new(config.epochs as u64);
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
     for epoch in 0..config.epochs {
+        loader.reset(true);
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (img, tgt) in batch {

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -169,11 +169,13 @@ fn run(
     math::reset_matrix_ops();
     let pb = ProgressBar::new(config.epochs as u64);
     pb.set_position(start_epoch as u64);
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
     for epoch in start_epoch..config.epochs {
+        loader.reset(true);
         let mut last_loss = 0.0;
         let mut f1_sum = 0.0;
         let mut sample_cnt: f32 = 0.0;
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (src, tgt) in batch {

--- a/src/bin/train_resnet.rs
+++ b/src/bin/train_resnet.rs
@@ -74,11 +74,14 @@ fn run(
 
     math::reset_matrix_ops();
 
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
+
     for epoch in 0..epochs {
+        loader.reset(true);
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
             for (img, tgt) in batch {

--- a/src/bin/train_rnn.rs
+++ b/src/bin/train_rnn.rs
@@ -67,10 +67,12 @@ fn run(
     let epochs = config.epochs;
     let pb = ProgressBar::new(epochs as u64);
     let mut step = 0usize;
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
 
     for epoch in 0..epochs {
+        loader.reset(true);
         let mut last_loss = 0.0;
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             rnn.zero_grad();
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;

--- a/src/data/dataloader.rs
+++ b/src/data/dataloader.rs
@@ -49,6 +49,14 @@ impl<'a, D: Dataset> DataLoader<'a, D> {
             _marker: std::marker::PhantomData,
         }
     }
+
+    /// Reset the internal iteration state and optionally shuffle the data.
+    pub fn reset(&mut self, shuffle: bool) {
+        self.index = 0;
+        if shuffle {
+            self.data.shuffle(&mut thread_rng());
+        }
+    }
 }
 
 impl<'a, D: Dataset> Iterator for DataLoader<'a, D> {

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -114,6 +114,8 @@ pub fn run(
     let pb = ProgressBar::new(epochs as u64);
     pb.set_position(start_epoch as u64);
 
+    let mut loader = DataLoader::<Mnist>::new(config.batch_size, false, None);
+
     for cb in callbacks.iter_mut() {
         cb.on_train_begin();
     }
@@ -123,11 +125,12 @@ pub fn run(
         for cb in callbacks.iter_mut() {
             cb.on_epoch_begin(epoch);
         }
+        loader.reset(true);
         let mut last_loss = 0.0f32;
         let mut f1_sum = 0.0f32;
         let mut sample_cnt = 0.0f32;
 
-        for batch in DataLoader::<Mnist>::new(config.batch_size, true, None) {
+        for batch in loader.by_ref() {
             let mut batch_loss = 0.0f32;
             let mut batch_f1 = 0.0f32;
 


### PR DESCRIPTION
## Summary
- add `reset` method to `DataLoader` for reusing datasets
- reuse a single `DataLoader` across epochs in training binaries

## Testing
- `cargo test` *(fails: failed to fetch model weights)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b8e6be2c832fab88c248d84ca1d1