### PR TITLE
Support dataset selection in API

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use std::process::Command;
-use vanillanoprop::{data, predict};
+use vanillanoprop::{data, predict, DatasetKind};
 
 mod common;
 
@@ -38,7 +38,7 @@ fn main() {
             } else {
                 Some(model.as_str())
             };
-            predict::run(model_opt, moe, num_experts);
+            predict::run(DatasetKind::Mnist, model_opt, moe, num_experts);
         }
         "predict-rnn" => {
             let (
@@ -59,7 +59,7 @@ fn main() {
                 _config,
                 _positional,
             ) = common::parse_cli(args[2..].iter().cloned());
-            predict::run(Some("rnn"), moe, num_experts);
+            predict::run(DatasetKind::Mnist, Some("rnn"), moe, num_experts);
         }
         "download" => data::download_mnist(),
         "train-backprop" | "train-elmo" | "train-noprop" | "train-lcm" | "train-rnn"

--- a/src/bin/web_server.rs
+++ b/src/bin/web_server.rs
@@ -1,20 +1,56 @@
 use actix_web::{web, App, HttpResponse, HttpServer};
+use serde::Deserialize;
 use vanillanoprop::config::Config;
+use vanillanoprop::data::DatasetKind;
 
 mod train_backprop;
 
-async fn train() -> HttpResponse {
+#[derive(Deserialize)]
+struct DatasetParam {
+    dataset: Option<String>,
+}
+
+fn parse_dataset(
+    query: &web::Query<DatasetParam>,
+    body: &Option<web::Json<DatasetParam>>,
+) -> Result<DatasetKind, HttpResponse> {
+    let name = body
+        .as_ref()
+        .and_then(|j| j.dataset.clone())
+        .or_else(|| query.dataset.clone())
+        .ok_or_else(|| HttpResponse::BadRequest().body("unsupported dataset"))?;
+    DatasetKind::from_str(&name)
+        .ok_or_else(|| HttpResponse::BadRequest().body("unsupported dataset"))
+}
+
+async fn train(
+    query: web::Query<DatasetParam>,
+    body: Option<web::Json<DatasetParam>>,
+) -> HttpResponse {
+    let dataset = match parse_dataset(&query, &body) {
+        Ok(ds) => ds,
+        Err(resp) => return resp,
+    };
     let config = Config::default();
+    let ds = dataset;
     let _ = web::block(move || {
-        train_backprop::run("sgd", false, 1, None, None, &config, None, None);
+        train_backprop::run(ds, "sgd", false, 1, None, None, &config, None, None);
     })
     .await;
     HttpResponse::Ok().body("training complete")
 }
 
-async fn infer() -> HttpResponse {
-    let _ = web::block(|| {
-        vanillanoprop::predict::run(None, false, 0);
+async fn infer(
+    query: web::Query<DatasetParam>,
+    body: Option<web::Json<DatasetParam>>,
+) -> HttpResponse {
+    let dataset = match parse_dataset(&query, &body) {
+        Ok(ds) => ds,
+        Err(resp) => return resp,
+    };
+    let ds = dataset;
+    let _ = web::block(move || {
+        vanillanoprop::predict::run(ds, None, false, 0);
     })
     .await;
     HttpResponse::Ok().body("inference complete")

--- a/src/data/datasets.rs
+++ b/src/data/datasets.rs
@@ -1,0 +1,28 @@
+use std::str::FromStr;
+
+/// Available datasets supported by the crate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DatasetKind {
+    /// MNIST handwritten digits dataset.
+    Mnist,
+    /// CIFAR-10 image dataset.
+    Cifar10,
+}
+
+impl DatasetKind {
+    /// Parse a dataset name into a `DatasetKind`.
+    pub fn from_str(name: &str) -> Option<Self> {
+        match name.to_lowercase().as_str() {
+            "mnist" => Some(DatasetKind::Mnist),
+            "cifar10" | "cifar-10" => Some(DatasetKind::Cifar10),
+            _ => None,
+        }
+    }
+}
+
+impl FromStr for DatasetKind {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        DatasetKind::from_str(s).ok_or(())
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,8 +1,10 @@
 pub mod dataloader;
 pub mod text;
 pub mod audio;
+pub mod datasets;
 
 pub use dataloader::{Cifar10, DataLoader, Dataset, Mnist};
+pub use datasets::DatasetKind;
 pub use text::TextDataset;
 pub use audio::AudioDataset;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,6 @@ pub mod train_fusion;
 pub mod util;
 pub mod weights;
 
-pub use data::{Cifar10, Dataset, Mnist};
+pub use data::{Cifar10, Dataset, DatasetKind, Mnist};
 pub use huggingface::fetch_hf_files;
 pub use weights::load_transformer_from_hf;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,4 +1,4 @@
-use crate::data::{DataLoader, Mnist};
+use crate::data::{Cifar10, DataLoader, DatasetKind, Mnist};
 use crate::layers::{Activation, Layer, LinearT, MixtureOfExpertsT};
 use crate::math::{self, Matrix};
 use crate::models::{DecoderT, EncoderT, LargeConceptModel, RnnCell, SimpleCNN, RNN};
@@ -15,11 +15,16 @@ fn to_matrix(seq: &[u8], vocab_size: usize) -> Matrix {
     m
 }
 
-pub fn run(model: Option<&str>, moe: bool, num_experts: usize) {
-    // pick a random image from the MNIST training pairs
-    let pairs: Vec<(Vec<u8>, usize)> = DataLoader::<Mnist>::new(1, true, None)
-        .flat_map(|b| b.iter().cloned())
-        .collect();
+pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: usize) {
+    // pick a random image from the requested dataset
+    let pairs: Vec<(Vec<u8>, usize)> = match dataset {
+        DatasetKind::Mnist => DataLoader::<Mnist>::new(1, true, None)
+            .flat_map(|b| b.iter().cloned())
+            .collect(),
+        DatasetKind::Cifar10 => DataLoader::<Cifar10>::new(1, true, None)
+            .flat_map(|b| b.iter().cloned())
+            .collect(),
+    };
     let mut rng = thread_rng();
     let idx = rng.gen_range(0..pairs.len());
     let (src, tgt) = &pairs[idx];


### PR DESCRIPTION
## Summary
- enumerate supported datasets (MNIST, CIFAR-10)
- allow `/train` and `/infer` endpoints to select dataset
- route dataset selection through training and inference

## Testing
- `cargo test` *(fails: failed to fetch model weights)*
