### PR TITLE
Add async job registry and SSE endpoints for training/inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,6 +3467,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vanillanoprop"
 version = "0.1.0"
 dependencies = [
@@ -3466,6 +3489,7 @@ dependencies = [
  "csv",
  "cust",
  "env_logger",
+ "futures-util",
  "glob",
  "hf-hub",
  "indicatif",
@@ -3485,8 +3509,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "toml",
  "ureq",
+ "uuid",
  "wide",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ nvrtc = { version = "0.1", optional = true }
 wide = "0.7"
 actix-web = "4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1", features = ["v4"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures-util = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_ProcessStatus", "Win32_System_Threading"] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -38,7 +38,8 @@ fn main() {
             } else {
                 Some(model.as_str())
             };
-            predict::run(DatasetKind::Mnist, model_opt, moe, num_experts);
+            let res = predict::run(DatasetKind::Mnist, model_opt, moe, num_experts);
+            println!("{}", res);
         }
         "predict-rnn" => {
             let (
@@ -59,7 +60,8 @@ fn main() {
                 _config,
                 _positional,
             ) = common::parse_cli(args[2..].iter().cloned());
-            predict::run(DatasetKind::Mnist, Some("rnn"), moe, num_experts);
+            let res = predict::run(DatasetKind::Mnist, Some("rnn"), moe, num_experts);
+            println!("{}", res);
         }
         "download" => data::download_mnist(),
         "train-backprop" | "train-elmo" | "train-noprop" | "train-lcm" | "train-rnn"

--- a/src/bin/web_server.rs
+++ b/src/bin/web_server.rs
@@ -1,13 +1,22 @@
 use actix_web::{web, App, HttpResponse, HttpServer};
-use serde::Deserialize;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio_stream::wrappers::BroadcastStream;
 use vanillanoprop::config::Config;
 use vanillanoprop::data::DatasetKind;
+use vanillanoprop::job::{JobRegistry, JobStatus};
 
 mod train_backprop;
 
 #[derive(Deserialize)]
 struct DatasetParam {
     dataset: Option<String>,
+}
+
+#[derive(Serialize)]
+struct JobId {
+    job_id: String,
 }
 
 fn parse_dataset(
@@ -24,6 +33,7 @@ fn parse_dataset(
 }
 
 async fn train(
+    registry: web::Data<JobRegistry>,
     query: web::Query<DatasetParam>,
     body: Option<web::Json<DatasetParam>>,
 ) -> HttpResponse {
@@ -31,16 +41,40 @@ async fn train(
         Ok(ds) => ds,
         Err(resp) => return resp,
     };
-    let config = Config::default();
-    let ds = dataset;
-    let _ = web::block(move || {
-        train_backprop::run(ds, "sgd", false, 1, None, None, &config, None, None);
-    })
-    .await;
-    HttpResponse::Ok().body("training complete")
+    let job_id = registry.create_job();
+    let job_id_resp = job_id.clone();
+    let reg = registry.clone();
+    tokio::spawn({
+        let reg = reg.clone();
+        let job_id = job_id.clone();
+        async move {
+            reg.set_status(&job_id, JobStatus::Running);
+            let config = Config::default();
+            let ds = dataset;
+            let reg2 = reg.clone();
+            let job_id2 = job_id.clone();
+            let res = tokio::task::spawn_blocking(move || {
+                train_backprop::run(ds, "sgd", false, 1, None, None, &config, None, None);
+            })
+            .await;
+            match res {
+                Ok(_) => {
+                    reg2.update_progress(&job_id2, 1.0);
+                    reg2.set_status(&job_id2, JobStatus::Completed);
+                    reg2.set_result(&job_id2, json!({"message": "training complete"}));
+                }
+                Err(e) => {
+                    reg2.set_status(&job_id2, JobStatus::Failed);
+                    reg2.set_result(&job_id2, json!({"error": format!("{e}")}));
+                }
+            }
+        }
+    });
+    HttpResponse::Ok().json(JobId { job_id: job_id_resp })
 }
 
 async fn infer(
+    registry: web::Data<JobRegistry>,
     query: web::Query<DatasetParam>,
     body: Option<web::Json<DatasetParam>>,
 ) -> HttpResponse {
@@ -48,18 +82,90 @@ async fn infer(
         Ok(ds) => ds,
         Err(resp) => return resp,
     };
-    let ds = dataset;
-    let _ = web::block(move || {
-        vanillanoprop::predict::run(ds, None, false, 0);
-    })
-    .await;
-    HttpResponse::Ok().body("inference complete")
+    let job_id = registry.create_job();
+    let job_id_resp = job_id.clone();
+    let reg = registry.clone();
+    tokio::spawn({
+        let reg = reg.clone();
+        let job_id = job_id.clone();
+        async move {
+            reg.set_status(&job_id, JobStatus::Running);
+            let ds = dataset;
+            let reg2 = reg.clone();
+            let job_id2 = job_id.clone();
+            let res = tokio::task::spawn_blocking(move || {
+                vanillanoprop::predict::run(ds, None, false, 0)
+            })
+            .await;
+            match res {
+                Ok(pred) => {
+                    reg2.update_progress(&job_id2, 1.0);
+                    reg2.set_status(&job_id2, JobStatus::Completed);
+                    reg2.set_result(&job_id2, pred);
+                }
+                Err(e) => {
+                    reg2.set_status(&job_id2, JobStatus::Failed);
+                    reg2.set_result(&job_id2, json!({"error": format!("{e}")}));
+                }
+            }
+        }
+    });
+    HttpResponse::Ok().json(JobId { job_id: job_id_resp })
+}
+
+async fn job_status(
+    registry: web::Data<JobRegistry>,
+    id: web::Path<String>,
+) -> HttpResponse {
+    match registry.get_info(&id) {
+        Some(info) => HttpResponse::Ok().json(info),
+        None => HttpResponse::NotFound().finish(),
+    }
+}
+
+async fn job_result(
+    registry: web::Data<JobRegistry>,
+    id: web::Path<String>,
+) -> HttpResponse {
+    match registry.get_result(&id) {
+        Some(res) => HttpResponse::Ok().json(res),
+        None => HttpResponse::NotFound().finish(),
+    }
+}
+
+async fn job_events(
+    registry: web::Data<JobRegistry>,
+    id: web::Path<String>,
+) -> HttpResponse {
+    if let Some(rx) = registry.subscribe(&id) {
+        let stream = BroadcastStream::new(rx).filter_map(|msg| async move {
+            match msg {
+                Ok(m) => Some(Ok::<_, actix_web::Error>(web::Bytes::from(format!("data: {}\n\n", m)))),
+                Err(_) => None,
+            }
+        });
+        HttpResponse::Ok()
+            .insert_header(("Content-Type", "text/event-stream"))
+            .streaming(stream)
+    } else {
+        HttpResponse::NotFound().finish()
+    }
 }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    HttpServer::new(|| App::new().route("/train", web::post().to(train)).route("/infer", web::post().to(infer)))
-        .bind(("0.0.0.0", 8080))?
-        .run()
-        .await
+    env_logger::init();
+    let registry = web::Data::new(JobRegistry::new());
+    HttpServer::new(move || {
+        App::new()
+            .app_data(registry.clone())
+            .route("/train", web::post().to(train))
+            .route("/infer", web::post().to(infer))
+            .route("/jobs/{id}/status", web::get().to(job_status))
+            .route("/jobs/{id}/result", web::get().to(job_result))
+            .route("/jobs/{id}/events", web::get().to(job_events))
+    })
+    .bind(("0.0.0.0", 8080))?
+    .run()
+    .await
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde::{Serialize};
+use serde_json::Value;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+#[derive(Clone, Serialize)]
+pub enum JobStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Clone, Serialize)]
+pub struct JobInfo {
+    pub status: JobStatus,
+    pub progress: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+}
+
+struct InternalJob {
+    info: JobInfo,
+    tx: broadcast::Sender<String>,
+}
+
+#[derive(Clone)]
+pub struct JobRegistry {
+    inner: Arc<Mutex<HashMap<String, InternalJob>>>,
+}
+
+impl JobRegistry {
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(HashMap::new())) }
+    }
+
+    pub fn create_job(&self) -> String {
+        let id = Uuid::new_v4().to_string();
+        let (tx, _rx) = broadcast::channel(100);
+        let job = InternalJob {
+            info: JobInfo {
+                status: JobStatus::Queued,
+                progress: 0.0,
+                result: None,
+            },
+            tx,
+        };
+        self.inner.lock().unwrap().insert(id.clone(), job);
+        id
+    }
+
+    pub fn set_status(&self, id: &str, status: JobStatus) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(job) = inner.get_mut(id) {
+            job.info.status = status.clone();
+            let _ = job.tx.send(serde_json::json!({"status": status}).to_string());
+        }
+    }
+
+    pub fn update_progress(&self, id: &str, progress: f32) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(job) = inner.get_mut(id) {
+            job.info.progress = progress;
+            let _ = job.tx.send(serde_json::json!({"progress": progress}).to_string());
+        }
+    }
+
+    pub fn set_result(&self, id: &str, result: Value) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(job) = inner.get_mut(id) {
+            job.info.result = Some(result.clone());
+            let _ = job.tx.send(serde_json::json!({"result": result}).to_string());
+        }
+    }
+
+    pub fn get_info(&self, id: &str) -> Option<JobInfo> {
+        self.inner.lock().unwrap().get(id).map(|j| j.info.clone())
+    }
+
+    pub fn get_result(&self, id: &str) -> Option<Value> {
+        self.inner.lock().unwrap().get(id).and_then(|j| j.info.result.clone())
+    }
+
+    pub fn subscribe(&self, id: &str) -> Option<broadcast::Receiver<String>> {
+        self.inner.lock().unwrap().get(id).map(|j| j.tx.subscribe())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod models;
 pub mod optim;
 pub mod positional;
 pub mod predict;
+pub mod job;
 pub mod rl;
 pub mod rng;
 pub mod tensor;


### PR DESCRIPTION
## Summary
- Introduce `JobRegistry` to track job status, progress, and results with broadcast channels
- Wrap training and inference in background tasks updating the registry and emitting SSE events
- Return inference predictions and ground-truth as JSON for frontend consumption

## Testing
- `cargo test` *(failed: test hf_loading)*

