### PR TITLE
Add SelfAdaptAgent for online language adaptation

### DIFF
--- a/src/rl/mod.rs
+++ b/src/rl/mod.rs
@@ -1,7 +1,9 @@
-pub mod treepo;
 pub mod language_env;
+pub mod self_adapt;
+pub mod treepo;
 
-pub use treepo::{Env, TreePoAgent};
 pub use language_env::LanguageEnv;
+pub use self_adapt::SelfAdaptAgent;
+pub use treepo::{Env, TreePoAgent};
 pub mod zero_shot_safe;
 pub use zero_shot_safe::*;

--- a/src/rl/self_adapt.rs
+++ b/src/rl/self_adapt.rs
@@ -1,0 +1,78 @@
+use super::{language_env::LanguageEnv, treepo::Env};
+use crate::math::{argmax, softmax_cross_entropy, Matrix};
+use crate::models::{DecoderT, TransformerEncoder};
+
+/// Agent that adapts itself online by updating a Transformer
+/// encoder/decoder on the reward signal from a [`LanguageEnv`].
+///
+/// At each step the current environment state is encoded, the decoder
+/// predicts the next token, the environment returns a reward and the
+/// true token. The agent then performs a backward pass and updates the
+/// model parameters using a simple Adam step.
+pub struct SelfAdaptAgent {
+    pub env: LanguageEnv,
+    pub encoder: TransformerEncoder,
+    pub decoder: DecoderT,
+    pub lr: f32,
+    pub vocab_size: usize,
+    state: Vec<u8>,
+}
+
+impl SelfAdaptAgent {
+    /// Construct a new agent with the given environment and models.
+    pub fn new(
+        mut env: LanguageEnv,
+        encoder: TransformerEncoder,
+        decoder: DecoderT,
+        lr: f32,
+        vocab_size: usize,
+    ) -> Self {
+        let state = env.reset();
+        Self {
+            env,
+            encoder,
+            decoder,
+            lr,
+            vocab_size,
+            state,
+        }
+    }
+
+    fn one_hot(&self, tokens: &[u8]) -> Matrix {
+        let seq_len = tokens.len().max(1);
+        let mut m = Matrix::zeros(seq_len, self.vocab_size);
+        for (i, &tok) in tokens.iter().enumerate() {
+            m.set(i, tok as usize, 1.0);
+        }
+        m
+    }
+
+    /// Perform a single environment step, update the models and return the reward.
+    pub fn step(&mut self) -> Option<f32> {
+        if self.env.is_terminal() {
+            return None;
+        }
+        let input = self.one_hot(&self.state);
+        self.encoder.zero_grad();
+        self.decoder.zero_grad();
+        let enc_out = self.encoder.forward_train(&input, None);
+        let logits = self.decoder.forward_train(&input, &enc_out);
+        let last_row = logits.rows - 1;
+        let row_slice = &logits.data[last_row * logits.cols..(last_row + 1) * logits.cols];
+        let action = argmax(row_slice) as u8;
+        let (next_state, reward) = self.env.step(action);
+        let target = *next_state.last().unwrap() as usize;
+        let (_loss, grad, _preds) = softmax_cross_entropy(&logits, &[target], last_row);
+        let grad_enc = self.decoder.backward(&grad);
+        self.encoder.backward(&grad_enc);
+        self.decoder.adam_step(self.lr, 0.9, 0.999, 1e-8, 0.0);
+        self.encoder.adam_step(self.lr, 0.9, 0.999, 1e-8, 0.0);
+        self.state = next_state;
+        Some(reward)
+    }
+
+    /// Reset the environment and clear internal state.
+    pub fn reset(&mut self) {
+        self.state = self.env.reset();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SelfAdaptAgent` wrapping a Transformer encoder/decoder and adapting to `LanguageEnv`
- re-export the agent from `rl` module

## Testing
- `cargo test` *(fails: failed to fetch model weights)*

