### PR TITLE
Add RMSNorm, SwiGLU feed-forward, and rotary encoding

### DIFF
--- a/src/layers/gated_ffn.rs
+++ b/src/layers/gated_ffn.rs
@@ -1,0 +1,154 @@
+use super::layer::Layer;
+use super::linear::LinearT;
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// SwiGLU style gated feed-forward layer.
+pub struct GatedFFNT {
+    pub w_in: LinearT,
+    pub w_out: LinearT,
+    u: Matrix,
+    v: Matrix,
+    v_act: Matrix,
+}
+
+impl GatedFFNT {
+    pub fn new(dim: usize, hidden: usize) -> Self {
+        Self {
+            w_in: LinearT::new(dim, hidden * 2),
+            w_out: LinearT::new(hidden, dim),
+            u: Matrix::zeros(0, 0),
+            v: Matrix::zeros(0, 0),
+            v_act: Matrix::zeros(0, 0),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Tensor {
+        let h = self.w_in.forward(x);
+        let rows = h.shape[0];
+        let cols = h.shape[1];
+        let hidden = cols / 2;
+        let mut gated = Matrix::zeros(rows, hidden);
+        for r in 0..rows {
+            for c in 0..hidden {
+                let u = h.data[r * cols + c];
+                let v = h.data[r * cols + hidden + c];
+                let s = 1.0 / (1.0 + (-v).exp());
+                let swish = v * s;
+                gated.data[r * hidden + c] = u * swish;
+            }
+        }
+        let g = Tensor::from_matrix(gated);
+        self.w_out.forward(&g)
+    }
+
+    pub fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        let h = self.w_in.forward_local(x);
+        let rows = h.rows;
+        let cols = h.cols;
+        let hidden = cols / 2;
+        self.u = Matrix::zeros(rows, hidden);
+        self.v = Matrix::zeros(rows, hidden);
+        self.v_act = Matrix::zeros(rows, hidden);
+        let mut gated = Matrix::zeros(rows, hidden);
+        for r in 0..rows {
+            for c in 0..hidden {
+                let u = h.data[r * cols + c];
+                let v = h.data[r * cols + hidden + c];
+                let s = 1.0 / (1.0 + (-v).exp());
+                let swish = v * s;
+                self.u.data[r * hidden + c] = u;
+                self.v.data[r * hidden + c] = v;
+                self.v_act.data[r * hidden + c] = swish;
+                gated.data[r * hidden + c] = u * swish;
+            }
+        }
+        self.w_out.forward_local(&gated)
+    }
+
+    pub fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        let grad_gated = self.w_out.backward(grad_out);
+        let rows = grad_gated.rows;
+        let hidden = grad_gated.cols;
+        let mut grad_h = Matrix::zeros(rows, hidden * 2);
+        for r in 0..rows {
+            for c in 0..hidden {
+                let g = grad_gated.data[r * hidden + c];
+                let u = self.u.data[r * hidden + c];
+                let v = self.v.data[r * hidden + c];
+                let swish = self.v_act.data[r * hidden + c];
+                grad_h.data[r * hidden * 2 + c] = g * swish;
+                let s = 1.0 / (1.0 + (-v).exp());
+                let swish_deriv = s + v * s * (1.0 - s);
+                grad_h.data[r * hidden * 2 + hidden + c] = g * u * swish_deriv;
+            }
+        }
+        self.w_in.backward(&grad_h)
+    }
+
+    pub fn fa_update(&mut self, grad_out: &Matrix, lr: f32) -> Matrix {
+        let grad_gated = self.w_out.fa_update(grad_out, lr);
+        let rows = grad_gated.rows;
+        let hidden = grad_gated.cols;
+        let mut grad_h = Matrix::zeros(rows, hidden * 2);
+        for r in 0..rows {
+            for c in 0..hidden {
+                let g = grad_gated.data[r * hidden + c];
+                let u = self.u.data[r * hidden + c];
+                let v = self.v.data[r * hidden + c];
+                let swish = self.v_act.data[r * hidden + c];
+                grad_h.data[r * hidden * 2 + c] = g * swish;
+                let s = 1.0 / (1.0 + (-v).exp());
+                let swish_deriv = s + v * s * (1.0 - s);
+                grad_h.data[r * hidden * 2 + hidden + c] = g * u * swish_deriv;
+            }
+        }
+        self.w_in.fa_update(&grad_h, lr)
+    }
+
+    pub fn zero_grad(&mut self) {
+        self.w_in.zero_grad();
+        self.w_out.zero_grad();
+    }
+
+    pub fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
+        self.w_in.adam_step(lr, beta1, beta2, eps, weight_decay);
+        self.w_out.adam_step(lr, beta1, beta2, eps, weight_decay);
+    }
+
+    pub fn parameters(&mut self) -> Vec<&mut LinearT> {
+        let (w1, w2) = (&mut self.w_in, &mut self.w_out);
+        vec![w1, w2]
+    }
+}
+
+impl Layer for GatedFFNT {
+    fn forward(&self, x: &Tensor) -> Tensor {
+        GatedFFNT::forward(self, x)
+    }
+
+    fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        GatedFFNT::forward_train(self, x)
+    }
+
+    fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        GatedFFNT::backward(self, grad_out)
+    }
+
+    fn zero_grad(&mut self) {
+        GatedFFNT::zero_grad(self);
+    }
+
+    fn fa_update(&mut self, grad_out: &Matrix, lr: f32) -> Matrix {
+        GatedFFNT::fa_update(self, grad_out, lr)
+    }
+
+    fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
+        GatedFFNT::adam_step(self, lr, beta1, beta2, eps, weight_decay);
+    }
+
+    fn parameters(&mut self) -> Vec<&mut LinearT> {
+        GatedFFNT::parameters(self)
+    }
+}
+

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -2,12 +2,14 @@ pub mod conv;
 pub mod dropout;
 pub mod embedding;
 pub mod feed_forward;
+pub mod gated_ffn;
 pub mod layer;
 pub mod leaky_relu;
 pub mod linear;
 pub mod mixture_of_experts;
 pub mod multi_head_attention;
 pub mod normalization;
+pub mod rms_norm;
 pub mod pooling;
 pub mod relu;
 pub mod rnn;
@@ -19,11 +21,13 @@ pub use conv::{Conv2d, ConvError};
 pub use dropout::Dropout;
 pub use embedding::EmbeddingT;
 pub use feed_forward::{Activation, FeedForwardT};
+pub use gated_ffn::GatedFFNT;
 pub use layer::Layer;
 pub use linear::LinearT;
 pub use mixture_of_experts::MixtureOfExpertsT;
 pub use multi_head_attention::MultiHeadAttentionT;
 pub use normalization::{BatchNorm, LayerNorm};
+pub use rms_norm::RmsNorm;
 pub use pooling::{
     avg_pool2d,
     avg_pool2d_backward,

--- a/src/layers/rms_norm.rs
+++ b/src/layers/rms_norm.rs
@@ -1,0 +1,187 @@
+use super::layer::Layer;
+use crate::math::Matrix;
+use crate::tensor::Tensor;
+
+/// Simple 1D parameter with Adam optimiser statistics.
+pub struct Param {
+    pub w: Vec<f32>,
+    grad: Vec<f32>,
+    m: Vec<f32>,
+    v: Vec<f32>,
+}
+
+impl Param {
+    fn new(dim: usize, init: f32) -> Self {
+        Self {
+            w: vec![init; dim],
+            grad: vec![0.0; dim],
+            m: vec![0.0; dim],
+            v: vec![0.0; dim],
+        }
+    }
+
+    fn zero_grad(&mut self) {
+        for g in self.grad.iter_mut() {
+            *g = 0.0;
+        }
+    }
+
+    fn sgd_step(&mut self, lr: f32, weight_decay: f32) {
+        for i in 0..self.w.len() {
+            let g = self.grad[i] + weight_decay * self.w[i];
+            self.w[i] -= lr * g;
+        }
+    }
+
+    fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, t: usize, weight_decay: f32) {
+        for i in 0..self.w.len() {
+            let g = self.grad[i] + weight_decay * self.w[i];
+            self.m[i] = beta1 * self.m[i] + (1.0 - beta1) * g;
+            self.v[i] = beta2 * self.v[i] + (1.0 - beta2) * g * g;
+            let m_hat = self.m[i] / (1.0 - beta1.powi(t as i32));
+            let v_hat = self.v[i] / (1.0 - beta2.powi(t as i32));
+            self.w[i] -= lr * m_hat / (v_hat.sqrt() + eps);
+        }
+    }
+}
+
+/// Root mean square normalisation layer with learnable scale parameter.
+pub struct RmsNorm {
+    pub gamma: Param,
+    eps: f32,
+    x: Matrix,
+    inv_rms: Vec<f32>,
+    t: usize,
+}
+
+impl RmsNorm {
+    pub fn new(dim: usize, eps: f32) -> Self {
+        Self {
+            gamma: Param::new(dim, 1.0),
+            eps,
+            x: Matrix::zeros(0, 0),
+            inv_rms: Vec::new(),
+            t: 0,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Tensor {
+        let rows = x.shape[0];
+        let cols = x.shape[1];
+        let mut out = Matrix::zeros(rows, cols);
+        for r in 0..rows {
+            let mut sum_sq = 0.0;
+            for c in 0..cols {
+                let v = x.data[r * cols + c];
+                sum_sq += v * v;
+            }
+            let inv_rms = 1.0 / ((sum_sq / cols as f32) + self.eps).sqrt();
+            for c in 0..cols {
+                let idx = r * cols + c;
+                out.data[idx] = x.data[idx] * self.gamma.w[c] * inv_rms;
+            }
+        }
+        Tensor::from_matrix(out)
+    }
+
+    pub fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        let rows = x.rows;
+        let cols = x.cols;
+        self.x = Matrix::from_vec(rows, cols, x.data.clone());
+        self.inv_rms = vec![0.0; rows];
+        let mut out = Matrix::zeros(rows, cols);
+        for r in 0..rows {
+            let mut sum_sq = 0.0;
+            for c in 0..cols {
+                let v = x.data[r * cols + c];
+                sum_sq += v * v;
+            }
+            let inv_rms = 1.0 / ((sum_sq / cols as f32) + self.eps).sqrt();
+            self.inv_rms[r] = inv_rms;
+            for c in 0..cols {
+                let idx = r * cols + c;
+                out.data[idx] = x.data[idx] * self.gamma.w[c] * inv_rms;
+            }
+        }
+        out
+    }
+
+    pub fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        let rows = grad_out.rows;
+        let cols = grad_out.cols;
+        let n = cols as f32;
+        let mut grad_input = Matrix::zeros(rows, cols);
+        for r in 0..rows {
+            let inv_rms = self.inv_rms[r];
+            let mut dot = 0.0;
+            for c in 0..cols {
+                let idx = r * cols + c;
+                let x_val = self.x.data[idx];
+                let go = grad_out.data[idx];
+                dot += self.gamma.w[c] * x_val * go;
+                self.gamma.grad[c] += go * x_val * inv_rms;
+            }
+            let inv_rms3 = inv_rms * inv_rms * inv_rms;
+            for c in 0..cols {
+                let idx = r * cols + c;
+                let x_val = self.x.data[idx];
+                let go = grad_out.data[idx];
+                grad_input.data[idx] = inv_rms * self.gamma.w[c] * go
+                    - inv_rms3 * x_val * dot / n;
+            }
+        }
+        grad_input
+    }
+
+    pub fn zero_grad(&mut self) {
+        self.gamma.zero_grad();
+    }
+
+    pub fn fa_update(&mut self, grad_out: &Matrix, lr: f32) -> Matrix {
+        let grad_input = self.backward(grad_out);
+        self.gamma.sgd_step(lr, 0.0);
+        self.zero_grad();
+        grad_input
+    }
+
+    pub fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
+        self.t += 1;
+        self.gamma
+            .adam_step(lr, beta1, beta2, eps, self.t, weight_decay);
+    }
+
+    pub fn parameters(&mut self) -> Vec<&mut crate::layers::linear::LinearT> {
+        Vec::new()
+    }
+}
+
+impl Layer for RmsNorm {
+    fn forward(&self, x: &Tensor) -> Tensor {
+        RmsNorm::forward(self, x)
+    }
+
+    fn forward_train(&mut self, x: &Matrix) -> Matrix {
+        RmsNorm::forward_train(self, x)
+    }
+
+    fn backward(&mut self, grad_out: &Matrix) -> Matrix {
+        RmsNorm::backward(self, grad_out)
+    }
+
+    fn zero_grad(&mut self) {
+        RmsNorm::zero_grad(self);
+    }
+
+    fn fa_update(&mut self, grad_out: &Matrix, lr: f32) -> Matrix {
+        RmsNorm::fa_update(self, grad_out, lr)
+    }
+
+    fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32, weight_decay: f32) {
+        RmsNorm::adam_step(self, lr, beta1, beta2, eps, weight_decay);
+    }
+
+    fn parameters(&mut self) -> Vec<&mut crate::layers::linear::LinearT> {
+        RmsNorm::parameters(self)
+    }
+}
+

--- a/src/positional.rs
+++ b/src/positional.rs
@@ -12,3 +12,29 @@ pub fn positional_encoding(seq_len: usize, model_dim: usize) -> Matrix {
     }
     enc
 }
+
+/// Apply rotary positional encoding to query and key matrices in-place.
+/// Both `q` and `k` are expected to have shape `(seq_len, dim)` where `dim`
+/// is even. `base_freq` controls the angular frequency of the rotation
+/// (typically `10000.0`).
+pub fn apply_rope(q: &mut Matrix, k: &mut Matrix, base_freq: f32) {
+    assert_eq!(q.rows, k.rows);
+    assert_eq!(q.cols, k.cols);
+    let dim = q.cols;
+    assert!(dim % 2 == 0, "RoPE requires an even dimension");
+    let half = dim / 2;
+    for pos in 0..q.rows {
+        for i in 0..half {
+            let theta = (pos as f32) / base_freq.powf(2.0 * i as f32 / dim as f32);
+            let (sin, cos) = theta.sin_cos();
+            let q_even = q.data[pos * dim + 2 * i];
+            let q_odd = q.data[pos * dim + 2 * i + 1];
+            q.data[pos * dim + 2 * i] = q_even * cos - q_odd * sin;
+            q.data[pos * dim + 2 * i + 1] = q_even * sin + q_odd * cos;
+            let k_even = k.data[pos * dim + 2 * i];
+            let k_odd = k.data[pos * dim + 2 * i + 1];
+            k.data[pos * dim + 2 * i] = k_even * cos - k_odd * sin;
+            k.data[pos * dim + 2 * i + 1] = k_even * sin + k_odd * cos;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add RMSNorm layer with forward/backward/adam implementations
- implement SwiGLU-based gated feed-forward layer
- add rotary positional encoding helper and expose new layers

## Testing
- `cargo test` *(fails: failed to fetch model weights)*
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68bb08932d6c832fad36826de771cc19