### PR TITLE
Fetch tokenizer and processor files from HF

### DIFF
--- a/src/huggingface.rs
+++ b/src/huggingface.rs
@@ -7,6 +7,8 @@ pub struct HfFiles {
     pub config: PathBuf,
     pub weights: PathBuf,
     pub tokenizer: Option<PathBuf>,
+    pub tokenizer_json: Option<PathBuf>,
+    pub processor: Option<PathBuf>,
 }
 
 /// Download `config.json` and weights for `model_id` from the Hugging Face Hub.
@@ -26,13 +28,17 @@ pub fn fetch_hf_files(model_id: &str, cache_dir: Option<&Path>) -> Result<HfFile
         Ok(p) => p,
         Err(_) => repo.get("pytorch_model.bin")?,
     };
-    let tokenizer = match repo.get("tokenizer.model") {
-        Ok(p) => Some(p),
-        Err(_) => None,
-    };
+    let tokenizer = repo.get("tokenizer.model").ok();
+    let tokenizer_json = repo.get("tokenizer.json").ok();
+    let processor = repo
+        .get("preprocessor_config.json")
+        .or_else(|_| repo.get("image_processor.json"))
+        .ok();
     Ok(HfFiles {
         config,
         weights,
         tokenizer,
+        tokenizer_json,
+        processor,
     })
 }

--- a/tests/fetch_hf_files.rs
+++ b/tests/fetch_hf_files.rs
@@ -1,0 +1,11 @@
+use vanillanoprop::fetch_hf_files;
+
+#[test]
+fn fetches_all_optional_files() {
+    let files = fetch_hf_files("hf-internal-testing/tiny-random-clip", None)
+        .expect("failed to fetch hf files");
+    assert!(files.config.exists());
+    assert!(files.weights.exists());
+    assert!(files.tokenizer_json.is_some());
+    assert!(files.processor.is_some());
+}


### PR DESCRIPTION
## Summary
- extend `HfFiles` with `tokenizer_json` and `processor` paths
- download `tokenizer.json` and `preprocessor_config.json` (or `image_processor.json`) when available
- add test ensuring these extra files are retrieved

## Testing
- `cargo test --test fetch_hf_files -- --nocapture` *(fails: RequestError ProxyConnect)*
