### PR TITLE
Add SmolVLM Hugging Face loader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,4 @@ pub use data::{Cifar10, Dataset, DatasetKind, Mnist};
 pub use huggingface::fetch_hf_files;
 pub use models::{LlamaConfig, LlamaModel};
 pub use reward::{NGramReward, RewardModel};
-pub use weights::{load_llama_from_hf, load_transformer_from_hf};
+pub use weights::{load_llama_from_hf, load_smolvlm_from_hf, load_transformer_from_hf};

--- a/src/models/resnet.rs
+++ b/src/models/resnet.rs
@@ -155,6 +155,16 @@ impl ResNet {
     pub fn parameters_mut(&mut self) -> (&mut Matrix, &mut Vec<f32>) {
         (&mut self.fc, &mut self.bias)
     }
+
+    /// Width of the hidden representation used by the network.
+    pub fn hidden_dim(&self) -> usize {
+        self.input.cols
+    }
+
+    /// Number of residual blocks stacked in the network.
+    pub fn num_blocks(&self) -> usize {
+        self.blocks.len()
+    }
 }
 
 /// Build a small ResNet-like architecture as a [`Model`] graph.
@@ -179,4 +189,3 @@ pub fn resnet_model(num_blocks: usize) -> Model {
     m.connect(prev, fc);
     m
 }
-

--- a/src/models/smolvlm.rs
+++ b/src/models/smolvlm.rs
@@ -56,4 +56,29 @@ impl SmolVLM {
         let fused_t = Tensor::new(fused, vec![1, vfeat.len() + text_feat.len()]);
         self.fusion.forward(&fused_t)
     }
+
+    /// Mutable accessors used by weight loading utilities.
+    pub fn vision_mut(&mut self) -> &mut ResNet {
+        &mut self.vision
+    }
+
+    /// Mutable access to the text encoder.
+    pub fn text_mut(&mut self) -> &mut TransformerEncoder {
+        &mut self.text
+    }
+
+    /// Mutable access to the fusion layer.
+    pub fn fusion_mut(&mut self) -> &mut LinearT {
+        &mut self.fusion
+    }
+
+    /// Dimension of the text representation.
+    pub fn text_dim(&self) -> usize {
+        self.text_dim
+    }
+
+    /// Size of the vocabulary used by the text encoder.
+    pub fn vocab_size(&self) -> usize {
+        self.vocab_size
+    }
 }


### PR DESCRIPTION
## Summary
- add `load_smolvlm_from_hf` to read SmolVLM configs and map Hugging Face tensor names
- expose accessors on `SmolVLM` and `ResNet` for weight loading
- re-export new loader from crate root

## Testing
- `cargo test` *(fails: failed to fetch hf files: RequestError(Transport(Transport { kind: ProxyConnect, message: None, url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("huggingface.co")), port: None, path: "/hf-internal-testing/tiny-random-clip/resolve/main/config.json", query: None, fragment: None }), source: None })))`

------
https://chatgpt.com/codex/tasks/task_e_68bb25a054c4832fba7de429c0b36165