### PR TITLE
Add SmolVLM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The library includes multiple built-in models. Training support varies across bi
 - **Recurrent neural network (RNN)** – trained with `train-rnn` only; it is unsupported in backprop, elmo, noprop, lcm, resnet and treepo binaries.
 - **ELMo encoder** – available through `train-elmo`. It cannot be trained with backprop, noprop, lcm, resnet, rnn or treepo commands.
 - **Tree Policy Optimization agent** – used by `train-treepo` and does not accept CNN, transformer, LCM, ResNet, RNN or ELMo models.
+- **SmolVLM** – `cargo run --example smolvlm` ([walkthrough](docs/examples/smolvlm.md)).
+  Downloads a tiny vision‑language model and runs a dummy image + prompt forward pass. Requires internet access.
 
 ### Logging
 

--- a/docs/examples/smolvlm.md
+++ b/docs/examples/smolvlm.md
@@ -1,0 +1,26 @@
+# SmolVLM Example
+
+## Overview
+
+Run a minimal vision-language model that mirrors SmolVLM-Instruct using the new loader.
+
+## Running the Example
+
+Downloads a small checkpoint and performs a dummy image + prompt forward pass.
+
+**Prerequisites:** internet access to fetch model weights.
+
+**Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)
+
+```bash
+cargo run --example smolvlm
+```
+
+## Explanation
+
+The example constructs a [`SmolVLM`](../../src/models/smolvlm.rs) instance, loads weights from the Hugging Face Hub and fuses image and text embeddings.
+
+## Next Steps
+
+See the [Hugging Face VLM example](hf_vlm.md) for a CLIP-style model.
+

--- a/examples/smolvlm.rs
+++ b/examples/smolvlm.rs
@@ -1,0 +1,35 @@
+use std::error::Error;
+use std::fs;
+
+use vanillanoprop::huggingface;
+use vanillanoprop::models::SmolVLM;
+use vanillanoprop::weights;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Download configuration and weights for a tiny SmolVLM model.
+    let files = huggingface::fetch_hf_files("hf-internal-testing/tiny-random-smolvlm", None)?;
+
+    // Parse the configuration to determine model dimensions.
+    let cfg_text = fs::read_to_string(&files.config)?;
+    let cfg: serde_json::Value = serde_json::from_str(&cfg_text)?;
+
+    let text_cfg = &cfg["text_config"];
+    let vision_cfg = &cfg["vision_config"];
+
+    let vocab_size = text_cfg["vocab_size"].as_u64().unwrap_or(1000) as usize;
+    let text_dim = text_cfg["hidden_size"].as_u64().unwrap_or(32) as usize;
+    let vision_dim = vision_cfg["hidden_size"].as_u64().unwrap_or(32) as usize;
+
+    // Construct the model and attempt to load pretrained weights.
+    let mut model = SmolVLM::new(vocab_size, vision_dim, text_dim);
+    let _ = weights::load_smolvlm_from_hf(&files.config, &files.weights, &mut model);
+
+    // Dummy 28x28 grayscale image and prompt tokens [0,1,2].
+    let image = vec![0u8; 28 * 28];
+    let prompt = [0usize, 1, 2];
+
+    let fused = model.forward(&image, &prompt);
+    println!("Fused embedding shape: {:?}", fused.shape);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add SmolVLM demo using new loader to fetch a tiny model and run a dummy forward pass
- document the SmolVLM example and link it from supported models

## Testing
- `cargo test` *(fails: network fetch hung; interrupted)*
´