### PR TITLE
feat: add optional hf_token to config

### DIFF
--- a/backprop_config.toml
+++ b/backprop_config.toml
@@ -3,3 +3,4 @@ epochs = 10
 batch_size = 32
 dataset = "mnist"
 learning_rate = [0.001]
+hf_token = ""

--- a/docs/examples/load_config.md
+++ b/docs/examples/load_config.md
@@ -3,7 +3,8 @@
 ## Overview
 
 Read training parameters from a `TOML` file and fall back to defaults when the
-file is missing.
+file is missing. Config files may also include an optional `hf_token` value for
+authenticated HuggingFace access.
 
 ## Running the Example
 =======

--- a/elmo_config.toml
+++ b/elmo_config.toml
@@ -3,3 +3,4 @@ epochs = 8
 batch_size = 16
 dataset = "mnist"
 learning_rate = [0.005]
+hf_token = ""

--- a/lcm_config.toml
+++ b/lcm_config.toml
@@ -4,3 +4,4 @@ gamma = 0.99
 lam = 0.95
 max_depth = 10
 rollout_steps = 10
+hf_token = ""

--- a/mobilenet_config.toml
+++ b/mobilenet_config.toml
@@ -3,3 +3,4 @@ epochs = 15
 batch_size = 64
 dataset = "mnist"
 learning_rate = [0.01]
+hf_token = ""

--- a/noprop_config.toml
+++ b/noprop_config.toml
@@ -3,3 +3,4 @@ epochs = 5
 batch_size = 8
 dataset = "mnist"
 learning_rate = [0.01]
+hf_token = ""

--- a/resnet_config.toml
+++ b/resnet_config.toml
@@ -3,3 +3,4 @@ epochs = 15
 batch_size = 64
 dataset = "mnist"
 learning_rate = [0.01]
+hf_token = ""

--- a/rnn_config.toml
+++ b/rnn_config.toml
@@ -3,3 +3,4 @@ epochs = 20
 batch_size = 32
 dataset = "mnist"
 learning_rate = [0.001]
+hf_token = ""

--- a/self_adapt_config.toml
+++ b/self_adapt_config.toml
@@ -2,3 +2,4 @@ reference = "hello world"
 episodes = 5
 lr = 0.001
 model_dim = 32
+hf_token = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,9 @@ pub struct Config {
     /// Whether to enable quantized inference where supported.
     #[serde(default)]
     pub quantized: bool,
+    /// Optional token for authenticated access to HuggingFace models.
+    #[serde(default)]
+    pub hf_token: Option<String>,
 }
 
 fn default_epochs() -> usize {
@@ -78,6 +81,7 @@ impl Default for Config {
             rollout_steps: default_rollout_steps(),
             learning_rate: default_learning_rates(),
             quantized: false,
+            hf_token: None,
         }
     }
 }

--- a/treepo_config.toml
+++ b/treepo_config.toml
@@ -5,3 +5,4 @@ rollout_steps = 10
 learning_rate = 0.1
 episodes = 10
 quantized = false
+hf_token = ""

--- a/zero_shot_safe_config.toml
+++ b/zero_shot_safe_config.toml
@@ -2,3 +2,4 @@ discount_factor = 0.99
 safety_thresholds = [-5.0]
 learning_rate = 0.1
 rollout_steps = 10
+hf_token = ""


### PR DESCRIPTION
## Summary
- add `hf_token` field to `Config`
- default to `None` and document in load_config example
- show optional `hf_token` in sample `*_config.toml`

## Testing
- `cargo test` *(fails: fetches_all_optional_files - network proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc34d4edc832fab41256e1c92c0c9