### PR TITLE
Expose HF token through examples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,10 @@ showcase core features of the framework.
 Pretrained Transformers can be loaded directly from the Hugging Face Hub:
 
 ```rust
-use vanillanoprop::{huggingface, weights, models::TransformerEncoder};
+use vanillanoprop::{config::Config, fetch_hf_files_with_cfg, weights, models::TransformerEncoder};
 
-let files = huggingface::fetch_hf_files("bert-base-uncased", None, None)?;
+let cfg = Config::from_path("backprop_config.toml").unwrap_or_default();
+let files = fetch_hf_files_with_cfg("bert-base-uncased", &cfg)?;
 let mut enc = TransformerEncoder::new(/* ... */);
 weights::load_transformer_from_hf(&files.config, &files.weights, &mut enc)?;
 ```

--- a/examples/hf_transformer.rs
+++ b/examples/hf_transformer.rs
@@ -1,14 +1,16 @@
 use std::error::Error;
 use std::fs;
 
-use vanillanoprop::huggingface;
+use vanillanoprop::config::Config;
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::TransformerEncoder;
 use vanillanoprop::weights;
+use vanillanoprop::fetch_hf_files_with_cfg;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Download configuration and weights for a tiny BERT model.
-    let files = huggingface::fetch_hf_files("hf-internal-testing/tiny-random-bert", None, None)?;
+    let cfg = Config::from_path("backprop_config.toml").unwrap_or_default();
+    let files = fetch_hf_files_with_cfg("hf-internal-testing/tiny-random-bert", &cfg)?;
 
     // Read dimensions from the Hugging Face configuration file.
     #[derive(serde::Deserialize)]

--- a/examples/hf_vlm.rs
+++ b/examples/hf_vlm.rs
@@ -1,14 +1,16 @@
 use std::error::Error;
 use std::fs;
 
-use vanillanoprop::huggingface;
+use vanillanoprop::config::Config;
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::{ResNet, TransformerEncoder};
 use vanillanoprop::weights;
+use vanillanoprop::fetch_hf_files_with_cfg;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Download configuration and weights for a tiny CLIP-like model.
-    let files = huggingface::fetch_hf_files("hf-internal-testing/tiny-random-clip", None, None)?;
+    let cfg = Config::from_path("backprop_config.toml").unwrap_or_default();
+    let files = fetch_hf_files_with_cfg("hf-internal-testing/tiny-random-clip", &cfg)?;
 
     // Read the top-level configuration file and extract nested text and vision configs.
     let cfg_text = fs::read_to_string(&files.config)?;

--- a/examples/smolvlm.rs
+++ b/examples/smolvlm.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
 use std::fs;
 
-use vanillanoprop::huggingface;
+use vanillanoprop::config::Config;
 use vanillanoprop::models::SmolVLM;
 use vanillanoprop::weights;
+use vanillanoprop::fetch_hf_files_with_cfg;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Download configuration and weights for a tiny SmolVLM model.
-    let files = huggingface::fetch_hf_files("hf-internal-testing/tiny-random-smolvlm", None, None)?;
+    let cfg = Config::from_path("backprop_config.toml").unwrap_or_default();
+    let files = fetch_hf_files_with_cfg("hf-internal-testing/tiny-random-smolvlm", &cfg)?;
 
     // Parse the configuration to determine model dimensions.
     let cfg_text = fs::read_to_string(&files.config)?;

--- a/src/fine_tune.rs
+++ b/src/fine_tune.rs
@@ -74,6 +74,9 @@ impl FineTune {
 /// fetched using [`fetch_hf_files`] and then loaded into the model by the
 /// caller-provided `load_fn`.
 ///
+/// `token` optionally supplies a Hugging Face access token for authenticated
+/// downloads.
+///
 /// `freeze_layers` specifies indices of parameters that should remain frozen
 /// during optimisation.
 ///

--- a/src/huggingface.rs
+++ b/src/huggingface.rs
@@ -2,6 +2,8 @@ use hf_hub::api::sync::{ApiBuilder, ApiError};
 use std::error::Error;
 use std::path::{Path, PathBuf};
 
+use crate::config::Config;
+
 /// Local paths to important files fetched from the Hugging Face Hub.
 pub struct HfFiles {
     pub config: PathBuf,
@@ -63,4 +65,14 @@ pub fn fetch_hf_files(
         tokenizer_json,
         processor,
     })
+}
+
+/// Convenience wrapper to fetch files using a [`Config`] for authentication.
+///
+/// Uses the `hf_token` field from the provided configuration if present.
+pub fn fetch_hf_files_with_cfg(
+    model_id: &str,
+    cfg: &Config,
+) -> Result<HfFiles, Box<dyn Error>> {
+    fetch_hf_files(model_id, None, cfg.hf_token.as_deref())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod util;
 pub mod weights;
 
 pub use data::{Cifar10, Dataset, DatasetKind, Mnist};
-pub use huggingface::fetch_hf_files;
+pub use huggingface::{fetch_hf_files, fetch_hf_files_with_cfg};
 pub use models::{LlamaConfig, LlamaModel};
 pub use reward::{NGramReward, RewardModel};
 pub use weights::{load_llama_from_hf, load_smolvlm_from_hf, load_transformer_from_hf};


### PR DESCRIPTION
## Summary
- add `fetch_hf_files_with_cfg` helper that uses `hf_token`
- forward Hugging Face token from config in examples
- make hf file tests read token from config or env and handle network failures

## Testing
- `./target/debug/deps/fetch_hf_files-4aff37000038050f --nocapture`

