### PR TITLE
Document Hugging Face token usage for Hub downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,16 +268,28 @@ showcase core features of the framework.
 
 ## Hugging Face models
 
-Pretrained Transformers can be loaded directly from the Hugging Face Hub:
+Pretrained Transformers can be loaded directly from the Hugging Face Hub.
+Place your access token in a configuration file under the `hf_token` key:
+
+```toml
+# backprop_config.toml
+hf_token = "hf_XXXXXXXXXXXXXXXX"
+```
+
+Load the config and pass the token to `fetch_hf_files` when downloading
+checkpoints:
 
 ```rust
-use vanillanoprop::{config::Config, fetch_hf_files_with_cfg, weights, models::TransformerEncoder};
+use vanillanoprop::{config::Config, fetch_hf_files, weights, models::TransformerEncoder};
 
 let cfg = Config::from_path("backprop_config.toml").unwrap_or_default();
-let files = fetch_hf_files_with_cfg("bert-base-uncased", &cfg)?;
+let files = fetch_hf_files("bert-base-uncased", None, cfg.hf_token.as_deref())?;
 let mut enc = TransformerEncoder::new(/* ... */);
 weights::load_transformer_from_hf(&files.config, &files.weights, &mut enc)?;
 ```
+
+**Security note:** configuration files containing secrets should not be
+committed to version control.
 
 ## License
 

--- a/docs/examples/hf_transformer.md
+++ b/docs/examples/hf_transformer.md
@@ -9,7 +9,9 @@ Fetch pretrained weights from the Hugging Face Hub and run a dummy inference.
 Shows how to fetch pretrained weights from the Hugging Face Hub and run a
 dummy inference.
 
-**Prerequisites:** internet access to download the model.
+**Prerequisites:** internet access to download the model. Include an
+`hf_token` in `backprop_config.toml` if the model requires authentication.
+Keep this token out of version control.
 
 **Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)
 

--- a/docs/examples/hf_vlm.md
+++ b/docs/examples/hf_vlm.md
@@ -7,7 +7,9 @@ Download a tiny vision-language model from the Hugging Face Hub and run a dummy 
 ## Running the Example
 Fetches a small CLIP-like checkpoint and produces embeddings for an image and a prompt.
 
-**Prerequisites:** internet access to download the model.
+**Prerequisites:** internet access to download the model. Add an `hf_token`
+to `backprop_config.toml` when authentication is needed and avoid committing
+files containing the token.
 
 **Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)
 


### PR DESCRIPTION
## Summary
- explain how to place `hf_token` in config files and use it with `fetch_hf_files`
- update Hugging Face example docs to mention the new token field
- warn against committing configs containing sensitive tokens

## Testing
- `cargo test` *(fails: failed to fetch model weights: RequestError(Transport { kind: ProxyConnect, .. }))*
