### PR TITLE
Add configs for each example and load them

### DIFF
--- a/configs/autoencoder.toml
+++ b/configs/autoencoder.toml
@@ -1,0 +1,3 @@
+epochs = 3
+batch_size = 16
+dataset = "mnist"

--- a/configs/autograd_custom_layer.toml
+++ b/configs/autograd_custom_layer.toml
@@ -1,0 +1,3 @@
+epochs = 1
+batch_size = 1
+dataset = "synthetic"

--- a/configs/hf_transformer.toml
+++ b/configs/hf_transformer.toml
@@ -1,0 +1,3 @@
+epochs = 5
+batch_size = 4
+dataset = "hf"

--- a/configs/hf_vlm.toml
+++ b/configs/hf_vlm.toml
@@ -1,0 +1,3 @@
+epochs = 5
+batch_size = 4
+dataset = "hf"

--- a/configs/load_config.toml
+++ b/configs/load_config.toml
@@ -1,0 +1,3 @@
+epochs = 10
+batch_size = 16
+dataset = "demo"

--- a/configs/mixture_of_experts.toml
+++ b/configs/mixture_of_experts.toml
@@ -1,0 +1,2 @@
+batch_size = 4
+epochs = 1

--- a/configs/mnist_cnn.toml
+++ b/configs/mnist_cnn.toml
@@ -1,0 +1,4 @@
+epochs = 5
+batch_size = 32
+dataset = "mnist"
+learning_rate = [0.01]

--- a/configs/mnist_gan.toml
+++ b/configs/mnist_gan.toml
@@ -1,0 +1,4 @@
+epochs = 2
+batch_size = 32
+dataset = "mnist"
+learning_rate = [0.0002]

--- a/configs/mnist_vgg.toml
+++ b/configs/mnist_vgg.toml
@@ -1,0 +1,4 @@
+epochs = 5
+batch_size = 32
+dataset = "mnist"
+learning_rate = [0.01]

--- a/configs/sequential_mlp.toml
+++ b/configs/sequential_mlp.toml
@@ -1,0 +1,1 @@
+learning_rate = [0.01]

--- a/configs/smolvlm.toml
+++ b/configs/smolvlm.toml
@@ -1,0 +1,3 @@
+epochs = 5
+batch_size = 4
+dataset = "hf"

--- a/configs/svd.toml
+++ b/configs/svd.toml
@@ -1,0 +1,3 @@
+epochs = 1
+batch_size = 1
+dataset = "svd"

--- a/configs/text_rnn.toml
+++ b/configs/text_rnn.toml
@@ -1,0 +1,1 @@
+learning_rate = [0.05]

--- a/configs/text_transformer.toml
+++ b/configs/text_transformer.toml
@@ -1,0 +1,1 @@
+learning_rate = [0.05]

--- a/configs/treepo.toml
+++ b/configs/treepo.toml
@@ -1,0 +1,5 @@
+gamma = 0.9
+lam = 0.95
+max_depth = 10
+rollout_steps = 10
+epochs = 5

--- a/configs/zero_shot_safe.toml
+++ b/configs/zero_shot_safe.toml
@@ -1,0 +1,3 @@
+gamma = 0.9
+lam = 0.95
+epochs = 1

--- a/docs/examples/autoencoder.md
+++ b/docs/examples/autoencoder.md
@@ -3,7 +3,8 @@
 ## Overview
 
 Demonstrates a tiny variational autoencoder that reconstructs MNIST
-images.
+images. Configuration such as batch size and epochs is read from
+`configs/autoencoder.toml`.
 
 **Prerequisites:** downloads the MNIST dataset on first run.
 

--- a/docs/examples/hf_transformer.md
+++ b/docs/examples/hf_transformer.md
@@ -3,6 +3,8 @@
 ## Overview
 
 Fetch pretrained weights from the Hugging Face Hub and run a dummy inference.
+Settings, including an optional `hf_token`, are read from
+`configs/hf_transformer.toml`.
 
 ## Running the Example
 =======
@@ -10,7 +12,7 @@ Shows how to fetch pretrained weights from the Hugging Face Hub and run a
 dummy inference.
 
 **Prerequisites:** internet access to download the model. Include an
-`hf_token` in `configs/backprop_config.toml` if the model requires authentication.
+`hf_token` in `configs/hf_transformer.toml` if the model requires authentication.
 Keep this token out of version control.
 
 **Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)

--- a/docs/examples/hf_vlm.md
+++ b/docs/examples/hf_vlm.md
@@ -2,13 +2,14 @@
 
 ## Overview
 
-Download a tiny vision-language model from the Hugging Face Hub and run a dummy image + text forward pass.
+Download a tiny vision-language model from the Hugging Face Hub and run a dummy image + text forward pass. The example reads
+settings such as the optional Hugging Face token from `configs/hf_vlm.toml`.
 
 ## Running the Example
 Fetches a small CLIP-like checkpoint and produces embeddings for an image and a prompt.
 
 **Prerequisites:** internet access to download the model. Add an `hf_token`
-to `configs/backprop_config.toml` when authentication is needed and avoid committing
+to `configs/hf_vlm.toml` when authentication is needed and avoid committing
 files containing the token.
 
 **Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)

--- a/docs/examples/load_config.md
+++ b/docs/examples/load_config.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-Read training parameters from a `TOML` file and fall back to defaults when the
-file is missing. Config files may also include an optional `hf_token` value for
-authenticated HuggingFace access.
+Read training parameters from a `TOML` file (`configs/load_config.toml`) and
+fall back to defaults when the file is missing. Config files may also include
+an optional `hf_token` value for authenticated HuggingFace access.
 
 ## Running the Example
 =======
 This example reads training parameters from a `TOML` file and falls back
 to defaults when the file is missing.
 
-**Prerequisites:** `configs/lcm_config.toml` in the repository.
+**Prerequisites:** `configs/load_config.toml` in the repository.
 
 **Demo command:** (use `cargo run --example`; training binaries run with
 `./run.sh`)
@@ -22,7 +22,7 @@ cargo run --example load_config
 
 ## Explanation
 
-The program prints which values were loaded from `configs/lcm_config.toml`,
+The program prints which values were loaded from `configs/load_config.toml`,
 illustrating how configuration drives the training setup.
 
 ## Next Steps

--- a/docs/examples/mixture_of_experts.md
+++ b/docs/examples/mixture_of_experts.md
@@ -3,7 +3,8 @@
 ## Overview
 
 Build a tiny mixture-of-experts layer and inspect the routing probabilities for
-each input.
+each input. The example reads a minimal config from
+`configs/mixture_of_experts.toml`.
 
 ## Running the Example
 =======

--- a/docs/examples/mnist_cnn.md
+++ b/docs/examples/mnist_cnn.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Train a small convolutional network on the MNIST digits dataset.
+Train a small convolutional network on the MNIST digits dataset. Hyperparameters
+such as `batch_size`, `epochs`, and `learning_rate` are loaded from
+`configs/mnist_cnn.toml`.
 
 ## Running the Example
 =======

--- a/docs/examples/smolvlm.md
+++ b/docs/examples/smolvlm.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Run a minimal vision-language model that mirrors SmolVLM-Instruct using the new loader.
+Run a minimal vision-language model that mirrors SmolVLM-Instruct using the new loader. Configuration, including an optional
+`hf_token`, is read from `configs/smolvlm.toml`.
 
 ## Running the Example
 

--- a/docs/examples/text_rnn.md
+++ b/docs/examples/text_rnn.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Build a simple LSTM for toy text classification.
+Build a simple LSTM for toy text classification. The learning rate is loaded
+from `configs/text_rnn.toml`.
 
 ## Running the Example
 =======

--- a/docs/examples/treepo.md
+++ b/docs/examples/treepo.md
@@ -9,13 +9,13 @@ Tree Policy Optimisation (TreePO) combines planning with policy optimisation.
 Tree Policy Optimisation (TreePO) combines planning with policy
 optimisation.
 
-**Prerequisites:** `configs/treepo_config.toml` in the repository.
+**Prerequisites:** `configs/treepo.toml` in the repository.
 
 **Training command:** (use `./run.sh`; demos run with `cargo run --example`)
 
 
 ```bash
-./run.sh train-treepo --config configs/treepo_config.toml
+cargo run --example treepo
 ```
 
 ## Explanation

--- a/docs/examples/zero_shot_safe.md
+++ b/docs/examples/zero_shot_safe.md
@@ -3,6 +3,7 @@
 ## Overview
 
 Demonstrates guarding policy updates with a safety check in a toy line world.
+Parameters such as `gamma` are loaded from `configs/zero_shot_safe.toml`.
 
 ## Running the Example
 =======

--- a/examples/autoencoder.rs
+++ b/examples/autoencoder.rs
@@ -1,12 +1,19 @@
+use vanillanoprop::config::Config;
 use vanillanoprop::data::{DataLoader, Mnist};
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::VAE;
 
 fn main() {
+    // Load configuration if available, falling back to defaults.
+    let cfg = Config::from_path("configs/autoencoder.toml").unwrap_or_default();
+
     // Use dataset utilities to load MNIST in mini-batches
     let mut vae = VAE::new(28 * 28, 128, 32);
 
-    for (i, batch) in DataLoader::<Mnist>::new(16, true, None).take(3).enumerate() {
+    for (i, batch) in DataLoader::<Mnist>::new(cfg.batch_size, true, None)
+        .take(cfg.epochs)
+        .enumerate()
+    {
         let mut loss_sum = 0.0f32;
         for (img, _) in batch {
             let input: Vec<f32> = img.iter().map(|&p| p as f32 / 255.0).collect();

--- a/examples/autograd_custom_layer.rs
+++ b/examples/autograd_custom_layer.rs
@@ -1,3 +1,4 @@
+use vanillanoprop::config::Config;
 use vanillanoprop::tensor::{Node, NodeRef, Tensor};
 
 struct MyLayer {
@@ -18,10 +19,16 @@ impl MyLayer {
 }
 
 fn main() {
+    // Load configuration and fall back to defaults if the file is missing.
+    let _cfg = Config::from_path("configs/autograd_custom_layer.toml").unwrap_or_default();
+
     let layer = MyLayer::new();
     let x = Tensor::new(vec![3.0], vec![1, 1]).into_node(true);
     let y = layer.forward(&x);
     Node::backward(&y);
     println!("grad x: {:?}", x.borrow().grad.as_ref().unwrap().data);
-    println!("grad w: {:?}", layer.weight.borrow().grad.as_ref().unwrap().data);
+    println!(
+        "grad w: {:?}",
+        layer.weight.borrow().grad.as_ref().unwrap().data
+    );
 }

--- a/examples/hf_transformer.rs
+++ b/examples/hf_transformer.rs
@@ -2,14 +2,14 @@ use std::error::Error;
 use std::fs;
 
 use vanillanoprop::config::Config;
+use vanillanoprop::fetch_hf_files_with_cfg;
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::TransformerEncoder;
 use vanillanoprop::weights;
-use vanillanoprop::fetch_hf_files_with_cfg;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Download configuration and weights for a tiny BERT model.
-    let cfg = Config::from_path("configs/backprop_config.toml").unwrap_or_default();
+    let cfg = Config::from_path("configs/hf_transformer.toml").unwrap_or_default();
     let files = fetch_hf_files_with_cfg("hf-internal-testing/tiny-random-bert", &cfg)?;
 
     // Read dimensions from the Hugging Face configuration file.

--- a/examples/hf_vlm.rs
+++ b/examples/hf_vlm.rs
@@ -2,14 +2,14 @@ use std::error::Error;
 use std::fs;
 
 use vanillanoprop::config::Config;
+use vanillanoprop::fetch_hf_files_with_cfg;
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::{ResNet, TransformerEncoder};
 use vanillanoprop::weights;
-use vanillanoprop::fetch_hf_files_with_cfg;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Download configuration and weights for a tiny CLIP-like model.
-    let cfg = Config::from_path("configs/backprop_config.toml").unwrap_or_default();
+    let cfg = Config::from_path("configs/hf_vlm.toml").unwrap_or_default();
     let files = fetch_hf_files_with_cfg("hf-internal-testing/tiny-random-clip", &cfg)?;
 
     // Read the top-level configuration file and extract nested text and vision configs.

--- a/examples/load_config.rs
+++ b/examples/load_config.rs
@@ -2,6 +2,6 @@ use vanillanoprop::config::Config;
 
 fn main() {
     // Load configuration from a file. Falls back to defaults if unavailable.
-    let cfg = Config::from_path("configs/lcm_config.toml").unwrap_or_default();
+    let cfg = Config::from_path("configs/load_config.toml").unwrap_or_default();
     println!("epochs: {} batch_size: {}", cfg.epochs, cfg.batch_size);
 }

--- a/examples/mixture_of_experts.rs
+++ b/examples/mixture_of_experts.rs
@@ -1,8 +1,13 @@
-use vanillanoprop::layers::{MixtureOfExpertsT, FeedForwardT, Activation, Layer};
+use vanillanoprop::config::Config;
+use vanillanoprop::layers::{Activation, FeedForwardT, Layer, MixtureOfExpertsT};
 use vanillanoprop::math::Matrix;
 use vanillanoprop::tensor::Tensor;
 
 fn main() {
+    // Load configuration and fall back to defaults when missing.
+    let cfg = Config::from_path("configs/mixture_of_experts.toml").unwrap_or_default();
+    println!("batch_size {}", cfg.batch_size);
+
     // Build three feed-forward expert networks
     let experts: Vec<Box<dyn Layer>> = (0..3)
         .map(|_| Box::new(FeedForwardT::new(4, 8, Activation::ReLU)) as Box<dyn Layer>)
@@ -12,8 +17,7 @@ fn main() {
     let mut moe = MixtureOfExpertsT::new(4, experts, 1);
 
     // Two sample inputs
-    let input = Matrix::from_vec(2, 4, vec![1.0, 2.0, 3.0, 4.0,
-                                           4.0, 3.0, 2.0, 1.0]);
+    let input = Matrix::from_vec(2, 4, vec![1.0, 2.0, 3.0, 4.0, 4.0, 3.0, 2.0, 1.0]);
 
     // Forward pass through the mixture
     let output = moe.forward_local(&input);

--- a/examples/mnist_gan.rs
+++ b/examples/mnist_gan.rs
@@ -1,13 +1,20 @@
 use rand::Rng;
+use vanillanoprop::config::Config;
 use vanillanoprop::data::{DataLoader, Mnist};
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::GAN;
 use vanillanoprop::rng::rng_from_env;
 
 fn main() {
+    // Load configuration and fall back to defaults when missing.
+    let cfg = Config::from_path("configs/mnist_gan.toml").unwrap_or_default();
+
     let mut gan = GAN::new(100);
     let mut rng = rng_from_env();
-    for (i, batch) in DataLoader::<Mnist>::new(32, true, None).take(2).enumerate() {
+    for (i, batch) in DataLoader::<Mnist>::new(cfg.batch_size, true, None)
+        .take(cfg.epochs)
+        .enumerate()
+    {
         let mut d_loss_sum = 0.0f32;
         let mut g_loss_sum = 0.0f32;
         for (img, _) in batch {
@@ -15,7 +22,7 @@ fn main() {
             let real_m = Matrix::from_vec(1, real.len(), real);
             let noise: Vec<f32> = (0..100).map(|_| rng.gen::<f32>() * 2.0 - 1.0).collect();
             let noise_m = Matrix::from_vec(1, 100, noise);
-            let (d_loss, g_loss) = gan.train_step(&real_m, &noise_m, 0.0002);
+            let (d_loss, g_loss) = gan.train_step(&real_m, &noise_m, cfg.learning_rate[0]);
             d_loss_sum += d_loss;
             g_loss_sum += g_loss;
         }

--- a/examples/sequential_mlp.rs
+++ b/examples/sequential_mlp.rs
@@ -1,9 +1,13 @@
+use vanillanoprop::config::Config;
 use vanillanoprop::layers::{Activation, FeedForwardT, LinearT, SoftmaxT};
 use vanillanoprop::math::Matrix;
 use vanillanoprop::models::Sequential;
 use vanillanoprop::tensor::Tensor;
 
 fn main() {
+    // Load configuration and fall back to defaults when missing.
+    let cfg = Config::from_path("configs/sequential_mlp.toml").unwrap_or_default();
+
     // Build a small multilayer perceptron using the Sequential container
     let mut mlp = Sequential::new();
     mlp.add_layer(Box::new(LinearT::new(4, 16)));
@@ -29,7 +33,7 @@ fn main() {
     mlp.zero_grad();
     mlp.backward(&grad);
     for layer in mlp.layers.iter_mut() {
-        layer.adam_step(0.01, 0.9, 0.999, 1e-8, 0.0);
+        layer.adam_step(cfg.learning_rate[0], 0.9, 0.999, 1e-8, 0.0);
     }
 
     // Inference with Tensor input

--- a/examples/smolvlm.rs
+++ b/examples/smolvlm.rs
@@ -2,13 +2,13 @@ use std::error::Error;
 use std::fs;
 
 use vanillanoprop::config::Config;
+use vanillanoprop::fetch_hf_files_with_cfg;
 use vanillanoprop::models::SmolVLM;
 use vanillanoprop::weights;
-use vanillanoprop::fetch_hf_files_with_cfg;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Download configuration and weights for a tiny SmolVLM model.
-    let cfg = Config::from_path("configs/backprop_config.toml").unwrap_or_default();
+    let cfg = Config::from_path("configs/smolvlm.toml").unwrap_or_default();
     let files = fetch_hf_files_with_cfg("hf-internal-testing/tiny-random-smolvlm", &cfg)?;
 
     // Parse the configuration to determine model dimensions.

--- a/examples/svd.rs
+++ b/examples/svd.rs
@@ -1,6 +1,8 @@
+use vanillanoprop::config::Config;
 use vanillanoprop::math::Matrix;
 
 fn main() {
+    let _cfg = Config::from_path("configs/svd.toml").unwrap_or_default();
     let m = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]);
     let (u, s, vt) = m.svd();
     let us = Matrix::matmul(&u, &s);

--- a/examples/text_rnn.rs
+++ b/examples/text_rnn.rs
@@ -1,7 +1,11 @@
+use vanillanoprop::config::Config;
 use vanillanoprop::math::{self, Matrix};
 use vanillanoprop::models::RNN;
 
 fn main() {
+    // Load configuration and fall back to defaults when missing.
+    let cfg = Config::from_path("configs/text_rnn.toml").unwrap_or_default();
+
     let data = vec![
         (vec![vec![1.0], vec![2.0], vec![3.0]], 1u8),
         (vec![vec![3.0], vec![2.0], vec![1.0]], 0u8),
@@ -19,7 +23,7 @@ fn main() {
         let (loss, grad, _) = math::softmax_cross_entropy(&logits, &[*label as usize], 0);
         rnn.zero_grad();
         rnn.backward(&grad);
-        rnn.adam_step(0.05, 0.9, 0.999, 1e-8, 0.0);
+        rnn.adam_step(cfg.learning_rate[0], 0.9, 0.999, 1e-8, 0.0);
         println!("sample {i} loss {loss}");
     }
 }

--- a/examples/treepo.rs
+++ b/examples/treepo.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use std::collections::HashMap;
+use vanillanoprop::config::Config;
 use vanillanoprop::rl::treepo::TreeNode;
 use vanillanoprop::rl::{Env, TreePoAgent};
 
@@ -41,23 +42,29 @@ impl Env for LineWorld {
 }
 
 fn main() {
-    // Create the environment and the TreePo agent.
-    // Hyperparameters:
-    // - gamma: discount factor for future rewards (0.9).
-    // - lam: GAE smoothing factor (0.95).
-    // - max_depth: maximum depth of the search tree (10).
-    // - rollout_steps: number of steps to simulate during rollouts (10).
-    // Try tweaking these values to see how learning changes.
+    // Load configuration and fall back to defaults when missing.
+    let cfg = Config::from_path("configs/treepo.toml").unwrap_or_default();
+
+    // Create the environment and the TreePo agent using hyperparameters
+    // from the configuration. Try tweaking these values to see how learning
+    // changes.
     let env = LineWorld {
         position: 0,
         goal: 5,
     };
-    let mut agent = TreePoAgent::new(env, 0.9, 0.95, 10, 10, 0.1);
+    let mut agent = TreePoAgent::new(
+        env,
+        cfg.gamma,
+        cfg.lam,
+        cfg.max_depth,
+        cfg.rollout_steps,
+        0.1,
+    );
 
     // Actions available to the agent: move left or right
     let actions = [-1, 1];
     let mut rng = rand::thread_rng();
-    let episodes = 5; // Increase for longer training
+    let episodes = cfg.epochs; // Increase for longer training
 
     for episode in 0..episodes {
         // Reset environment and root node at the start of each episode

--- a/examples/zero_shot_safe.rs
+++ b/examples/zero_shot_safe.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use vanillanoprop::config::Config;
 use vanillanoprop::rl::zero_shot_safe::{SafeEnv, ZeroShotSafeAgent};
 use vanillanoprop::rl::Env;
 
@@ -37,6 +38,10 @@ impl SafeEnv for SafeLineWorld {
 }
 
 fn main() {
+    // Load configuration and fall back to defaults if missing.
+    let cfg = Config::from_path("configs/zero_shot_safe.toml").unwrap_or_default();
+    println!("using gamma {}", cfg.gamma);
+
     // Create environment and agent guarding policy updates with a safety check.
     let env = SafeLineWorld {
         position: 0,


### PR DESCRIPTION
## Summary
- add `configs/<example>.toml` with sensible defaults
- update examples to read their own config files, falling back to defaults
- document the new config files in example docs

## Testing
- `cargo run --example autograd_custom_layer`
- `cargo run --example treepo`
- `cargo run --example autoencoder` *(fails: invalid gzip header for MNIST download)*
- `cargo run --example hf_vlm` *(fails: RequestError ProxyConnect for huggingface.co)*
