### PR TITLE
feat: load image from file for smolvlm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,10 @@ The library includes multiple built-in models. Training support varies across bi
 - **Recurrent neural network (RNN)** – trained with `train-rnn` only; it is unsupported in backprop, elmo, noprop, lcm, resnet and treepo binaries.
 - **ELMo encoder** – available through `train-elmo`. It cannot be trained with backprop, noprop, lcm, resnet, rnn or treepo commands.
 - **Tree Policy Optimization agent** – used by `train-treepo` and does not accept CNN, transformer, LCM, ResNet, RNN or ELMo models.
-- **SmolVLM** – `cargo run --example smolvlm` ([walkthrough](docs/examples/smolvlm.md)).
-  Downloads a tiny vision‑language model and runs a dummy image + prompt forward pass. Requires internet access.
+- **SmolVLM** – `cargo run --example smolvlm --features vlm path/to/image.png`
+  ([walkthrough](docs/examples/smolvlm.md)). Downloads a tiny vision‑language
+  model, loads an image and runs an image + prompt forward pass. Requires
+  internet access.
 
 ### Logging
 

--- a/docs/examples/smolvlm.md
+++ b/docs/examples/smolvlm.md
@@ -7,14 +7,17 @@ Run a minimal vision-language model that mirrors SmolVLM-Instruct using the new 
 
 ## Running the Example
 
-Downloads a small checkpoint and performs a dummy image + prompt forward pass.
+Downloads a small checkpoint and performs an image + prompt forward pass.
 
-**Prerequisites:** internet access to fetch model weights.
+**Prerequisites:**
 
-**Demo command:** (use `cargo run --example`; training binaries use `./run.sh`)
+- Internet access to fetch model weights.
+- Compile with `--features vlm` to pull in the `image` dependency.
+
+**Demo command:**
 
 ```bash
-cargo run --example smolvlm
+cargo run --example smolvlm --features vlm path/to/image.png
 ```
 
 ## Explanation

--- a/examples/smolvlm.rs
+++ b/examples/smolvlm.rs
@@ -1,5 +1,10 @@
+// Compile with `--features vlm` to enable the `image` crate.
+use std::env;
 use std::error::Error;
 use std::fs;
+use std::process;
+
+use image::imageops::FilterType;
 
 use vanillanoprop::config::Config;
 use vanillanoprop::fetch_hf_files_with_cfg;
@@ -7,6 +12,12 @@ use vanillanoprop::models::SmolVLM;
 use vanillanoprop::weights;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Expect an image path as the first argument.
+    let path = env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("Usage: cargo run --example smolvlm --features vlm <IMAGE_PATH>");
+        process::exit(1);
+    });
+
     // Download configuration and weights for a tiny SmolVLM model.
     let cfg = Config::from_path("configs/smolvlm.toml").unwrap_or_default();
     let files = fetch_hf_files_with_cfg("katuni4ka/tiny-random-smolvlm2", &cfg)?;
@@ -26,8 +37,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut model = SmolVLM::new(vocab_size, vision_dim, text_dim);
     let _ = weights::load_smolvlm_from_hf(&files.config, &files.weights, &mut model);
 
-    // Dummy 28x28 grayscale image and prompt tokens [0,1,2].
-    let image = vec![0u8; 28 * 28];
+    // Load the image, convert to 28x28 grayscale, and collect bytes.
+    let image = image::open(path)?
+        .grayscale()
+        .resize_exact(28, 28, FilterType::Triangle)
+        .to_luma8()
+        .into_raw();
     let prompt = [0usize, 1, 2];
 
     let fused = model.forward(&image, &prompt);


### PR DESCRIPTION
## Summary
- allow passing an image path to the `smolvlm` example
- preprocess the image with the `image` crate when `--features vlm` is enabled
- document new usage and feature flag requirement

## Testing
- `cargo check --example smolvlm --features vlm`
- `cargo test --features vlm` *(fails: failed to fetch model weights: RequestError(Transport { kind: ProxyConnect, ... }))*

