### PR TITLE
gate smolvlm example behind vlm feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,11 @@ path = "src/bin/web_server.rs"
 name = "train_self_adapt"
 path = "src/bin/train_self_adapt.rs"
 
+[[example]]
+name = "smolvlm"
+path = "examples/smolvlm.rs"
+required-features = ["vlm"]
+
 [dev-dependencies]
 criterion = "0.5"
 


### PR DESCRIPTION
## Summary
- gate the `smolvlm` example behind the `vlm` feature so it's built only when explicitly enabled

## Testing
- `cargo fmt --all`
- `cargo check --examples`
- `cargo test` *(fails: test `hf_loading` failed)*
