### PR TITLE
Decode SmolVLM output to text

### DIFF
--- a/docs/examples/smolvlm.md
+++ b/docs/examples/smolvlm.md
@@ -3,11 +3,12 @@
 ## Overview
 
 Run a minimal vision-language model that mirrors SmolVLM-Instruct using the new loader. Configuration, including an optional
-`hf_token`, is read from `configs/smolvlm.toml`.
+`hf_token`, is read from `configs/smolvlm.toml` and a tokenizer dictionary is fetched so the model's output can be decoded.
 
 ## Running the Example
 
-Downloads a small checkpoint and performs an image + prompt forward pass.
+Downloads a small checkpoint and performs an image + prompt forward pass. The tokenizer vocabulary is loaded and used to map
+model outputs back to readable text.
 
 **Prerequisites:**
 
@@ -22,7 +23,7 @@ cargo run --example smolvlm --features vlm path/to/image.png
 
 ## Explanation
 
-The example constructs a [`SmolVLM`](../../src/models/smolvlm.rs) instance, loads weights from the Hugging Face Hub and fuses image and text embeddings.
+The example constructs a [`SmolVLM`](../../src/models/smolvlm.rs) instance, loads weights and a tokenizer from the Hugging Face Hub, fuses image and text embeddings, then applies an `argmax` over the vocabulary dimension to obtain token ids which are decoded to text.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- load Hugging Face tokenizer in smolvlm example
- convert model output matrix to token IDs and decode to text
- document tokenizer download and decoding steps

## Testing
- `cargo test` *(fails: test failed, to rerun pass `--test hf_loading`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc804fae1c832fa0b17f7072564fa0