### PR TITLE
Handle SentencePiece tokenizer in SmolVLM example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2303,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4c95afc2d0dc13b57f6d7c690a7d2da4afc2226927c0603d7c7998be0124c4"
 dependencies = [
  "bytes 0.5.6",
- "prost",
+ "prost 0.6.1",
  "prost-build",
 ]
 
@@ -2676,7 +2696,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.6",
- "prost-derive",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes 1.10.1",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -2691,7 +2721,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
+ "prost 0.6.1",
  "prost-types",
  "tempfile",
  "which 3.1.1",
@@ -2711,13 +2741,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes 0.5.6",
- "prost",
+ "prost 0.6.1",
 ]
 
 [[package]]
@@ -3202,6 +3245,32 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "sentencepiece"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6b3200e8a889de07f7b449367b6bb33970a97cd7ec6ebf3d25aef0880db5a"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits 0.2.19",
+ "prost 0.14.1",
+ "prost-derive 0.14.1",
+ "sentencepiece-sys",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "sentencepiece-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b63807dd454316f8d12af1c6d5cd182eacb6f94ebee5d059a1fe6fdcafaf61a"
+dependencies = [
+ "cc",
+ "cmake",
+ "pkg-config",
+]
 
 [[package]]
 name = "serde"
@@ -3955,11 +4024,12 @@ dependencies = [
  "ndarray",
  "nvrtc",
  "onnx-pb",
- "prost",
+ "prost 0.6.1",
  "rand 0.8.5",
  "rand_distr",
  "rayon 1.11.0",
  "safetensors",
+ "sentencepiece",
  "serde",
  "serde_json",
  "tokenizers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ matrixmultiply = ["dep:matrixmultiply"]
 cuda = ["dep:cust", "dep:nvrtc"]
 rayon = []
 llama = ["dep:tokenizers"]
-vlm = ["dep:image", "dep:tokenizers"]
+vlm = ["dep:image", "dep:tokenizers", "dep:sentencepiece"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -47,6 +47,7 @@ futures-util = "0.3"
 actix-files = "0.6"
 tokenizers = { version = "0.15", optional = true }
 image = { version = "0.24", optional = true }
+sentencepiece = { version = "0.12", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_ProcessStatus", "Win32_System_Threading"] }


### PR DESCRIPTION
## Summary
- Support both JSON and SentencePiece tokenizers in the SmolVLM example
- Add optional `sentencepiece` dependency to the `vlm` feature

## Testing
- `cargo test` *(fails: failed to fetch model weights: RequestError(Transport { kind: ProxyConnect, .. }))*
- `cargo run --example smolvlm --features vlm dummy.pgm` *(fails: RequestError(Transport { kind: ProxyConnect, .. }))*
