### PR TITLE
Use internal tokenizer in SmolVLM example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,15 +615,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,17 +2410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,7 +2545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4c95afc2d0dc13b57f6d7c690a7d2da4afc2226927c0603d7c7998be0124c4"
 dependencies = [
  "bytes 0.5.6",
- "prost 0.6.1",
+ "prost",
  "prost-build",
 ]
 
@@ -2813,17 +2793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.6",
- "prost-derive 0.6.1",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
-dependencies = [
- "bytes 1.10.1",
- "prost-derive 0.14.1",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2838,7 +2808,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.6.1",
+ "prost",
  "prost-types",
  "tempfile",
  "which 3.1.1",
@@ -2858,26 +2828,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes 0.5.6",
- "prost 0.6.1",
+ "prost",
 ]
 
 [[package]]
@@ -3362,32 +3319,6 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "sentencepiece"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6b3200e8a889de07f7b449367b6bb33970a97cd7ec6ebf3d25aef0880db5a"
-dependencies = [
- "libc",
- "num-derive",
- "num-traits 0.2.19",
- "prost 0.14.1",
- "prost-derive 0.14.1",
- "sentencepiece-sys",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "sentencepiece-sys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b63807dd454316f8d12af1c6d5cd182eacb6f94ebee5d059a1fe6fdcafaf61a"
-dependencies = [
- "cc",
- "cmake",
- "pkg-config",
-]
 
 [[package]]
 name = "serde"
@@ -4142,12 +4073,11 @@ dependencies = [
  "ndarray",
  "nvrtc",
  "onnx-pb",
- "prost 0.6.1",
+ "prost",
  "rand 0.8.5",
  "rand_distr",
  "rayon 1.11.0",
  "safetensors",
- "sentencepiece",
  "serde",
  "serde_json",
  "tokenizers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ matrixmultiply = ["dep:matrixmultiply"]
 cuda = ["dep:cust", "dep:nvrtc"]
 rayon = []
 llama = ["dep:tokenizers"]
-vlm = ["dep:image", "dep:tokenizers", "dep:sentencepiece"]
+vlm = ["dep:image"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -47,7 +47,6 @@ futures-util = "0.3"
 actix-files = "0.6"
 tokenizers = { version = "0.15", optional = true }
 image = { version = "0.24", optional = true }
-sentencepiece = { version = "0.12", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_ProcessStatus", "Win32_System_Threading"] }

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ The library includes multiple built-in models. Training support varies across bi
 - **Tree Policy Optimization agent** – used by `train-treepo` and does not accept CNN, transformer, LCM, ResNet, RNN or ELMo models.
 - **SmolVLM** – `cargo run --example smolvlm --features vlm path/to/image.png`
   ([walkthrough](docs/examples/smolvlm.md)). Downloads a tiny vision‑language
-  model, loads an image and runs an image + prompt forward pass. Requires
-  internet access.
+  model, loads `tokenizer.json` with the internal tokenizer, loads an image and
+  runs an image + prompt forward pass. Requires internet access.
 
 ### Logging
 

--- a/docs/examples/smolvlm.md
+++ b/docs/examples/smolvlm.md
@@ -3,12 +3,11 @@
 ## Overview
 
 Run a minimal vision-language model that mirrors SmolVLM-Instruct using the new loader. Configuration, including an optional
-`hf_token`, is read from `configs/smolvlm.toml` and a tokenizer dictionary is fetched so the model's output can be decoded.
+`hf_token`, is read from `configs/smolvlm.toml` and a `tokenizer.json` is fetched and parsed by the internal tokenizer so the model's output can be decoded.
 
 ## Running the Example
 
-Downloads a small checkpoint and performs an image + prompt forward pass. The tokenizer vocabulary is loaded and used to map
-model outputs back to readable text.
+Downloads a small checkpoint and performs an image + prompt forward pass. The `tokenizer.json` vocabulary is loaded by the built-in tokenizer and used to map model outputs back to readable text.
 
 **Prerequisites:**
 
@@ -23,7 +22,7 @@ cargo run --example smolvlm --features vlm path/to/image.png
 
 ## Explanation
 
-The example constructs a [`SmolVLM`](../../src/models/smolvlm.rs) instance, loads weights and a tokenizer from the Hugging Face Hub, fuses image and text embeddings, then applies an `argmax` over the vocabulary dimension to obtain token ids which are decoded to text.
+The example constructs a [`SmolVLM`](../../src/models/smolvlm.rs) instance, loads weights and a tokenizer JSON file from the Hugging Face Hub, fuses image and text embeddings, then applies an `argmax` over the vocabulary dimension to obtain token ids which are decoded to text by the internal tokenizer.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- replace example `Decoder` with `vanillanoprop::tokenizer::Tokenizer`
- drop SentencePiece fallback and require `tokenizer.json`
- document built-in tokenizer and slim `vlm` feature

## Testing
- `cargo test` *(fails: test hf_loading)*
- `cargo check --example smolvlm --features vlm`
