### PR TITLE
Handle optional BOM in tokenizer JSON

### DIFF
--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -29,8 +29,11 @@ enum ModelType {
 impl Tokenizer {
     /// Build a tokenizer from a HuggingFace `tokenizer.json` file.
     pub fn from_json(path: &Path) -> Result<Self, Box<dyn Error>> {
-        let data = fs::read_to_string(path)?;
-        let json: TokenizerConfig = serde_json::from_str(&data)?;
+        let mut data = fs::read(path)?;
+        if data.starts_with(&[0xEF, 0xBB, 0xBF]) {
+            data.drain(..3);
+        }
+        let json: TokenizerConfig = serde_json::from_slice(&data)?;
 
         let mut vocab = json.model.vocab;
         if let Some(extra) = &json.added_tokens {


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM from tokenizer JSON before parsing

## Testing
- `cargo test -q` *(fails: hf_loading - failed to fetch model weights: RequestError(Transport { kind: ProxyConnect, message: None, url: Some(Url { scheme: "https", host: Some(Domain("huggingface.co")), path: "/hf-internal-testing/tiny-random-bert/resolve/main/model.safetensors", query: None, fragment: None }), source: None })))*
