### PR TITLE
Make Rayon an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 kai = []
 matrixmultiply = ["dep:matrixmultiply"]
 cuda = ["dep:cust", "dep:nvrtc"]
-rayon = []
+rayon = ["dep:rayon", "ndarray/rayon"]
 llama = []
 vlm = ["dep:image"]
 
@@ -24,7 +24,7 @@ cifar_10_loader = "0.2"
 libc = "0.2"
 log = "0.4"
 env_logger = "0.11"
-rayon = "1.8"
+rayon = { version = "1.8", optional = true }
 toml = "0.8"
 csv = "1"
 nalgebra = { version = "0.34" }
@@ -33,7 +33,7 @@ prost = "0.6"
 hf-hub = "0.4"
 ureq = "2"
 safetensors = "0.6"
-ndarray = { version = "0.15", features = ["rayon"] }
+ndarray = { version = "0.15" }
 matrixmultiply = { version = "0.3", optional = true }
 cust = { version = "0.3", optional = true }
 nvrtc = { version = "0.1", optional = true }


### PR DESCRIPTION
## Summary
- gate Rayon usage behind a `rayon` feature
- conditionally parallelize math helpers only when `rayon` is enabled

## Testing
- `cargo check`
- `cargo check --features rayon`


------
https://chatgpt.com/codex/tasks/task_e_68c552411f24832f926fbf192ef2b1ef