### PR TITLE
feat: add simple timestamped logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,54 +39,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
-dependencies = [
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -294,12 +250,6 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -522,29 +472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 dependencies = [
  "num-traits 0.1.43",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex 1.11.2",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -909,12 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,30 +867,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "jpeg-decoder"
@@ -1065,9 +962,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lzw"
@@ -1312,12 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
 name = "onnx-pb"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,21 +1359,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]
@@ -2086,12 +1962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,11 +1982,9 @@ dependencies = [
  "criterion",
  "csv",
  "cust",
- "env_logger",
  "glob",
  "image 0.24.9",
  "libc",
- "log",
  "matrixmultiply",
  "mnist",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ rand_distr = "0.4"
 mnist = { version = "0.6", features = ["download"] }
 cifar_10_loader = "0.2"
 libc = "0.2"
-log = "0.4"
-env_logger = "0.11"
 rayon = { version = "1.8", optional = true }
 toml = "0.8"
 csv = "1"

--- a/README.md
+++ b/README.md
@@ -119,17 +119,14 @@ The library includes multiple built-in models. Training support varies across bi
 
 ### Logging
 
-All binaries use the [`log`](https://crates.io/crates/log) facade with
-`env_logger` for output. Set the desired verbosity with the new
-`--log-level` flag or silence logs with `--quiet`:
+All binaries use a lightweight built-in logger that prints messages with
+timestamps. Control verbosity with the `--log-level` flag or silence logs
+with `--quiet`:
 
 ```bash
-./run.sh train-noprop --log-level debug
+./run.sh train-noprop --log-level warn
 ./run.sh train-noprop --quiet
 ```
-
-The `RUST_LOG` environment variable is still honoured when the flag is
-omitted.
 
 ### AutoML
 

--- a/scripts/plot_metrics.rs
+++ b/scripts/plot_metrics.rs
@@ -15,7 +15,6 @@ struct MetricRecord {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
     let path = env::args()
         .nth(1)
         .unwrap_or_else(|| "runs/example/metrics.jsonl".to_string());

--- a/src/bin/compare.rs
+++ b/src/bin/compare.rs
@@ -64,7 +64,7 @@ fn train_backprop(epochs: usize) -> (f32, usize, usize, u64) {
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
         pb.inc(1);
-        log::info!(
+        vanillanoprop::info!(
             "backprop epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"
         );
         if avg_f1 > best_f1 {
@@ -152,7 +152,7 @@ fn train_noprop(epochs: usize) -> (f32, usize, usize, u64) {
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
         pb.inc(1);
-        log::info!("noprop epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
+        vanillanoprop::info!("noprop epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         if avg_f1 > best_f1 {
             best_f1 = avg_f1;
         }
@@ -168,16 +168,16 @@ fn main() {
     let _ = common::init_logging();
     download_mnist();
     let epochs = 5;
-    log::info!("Running backpropagation for {epochs} epochs...");
+    vanillanoprop::info!("Running backpropagation for {epochs} epochs...");
     let (bp_f1, bp_add, bp_mul, bp_mem) = train_backprop(epochs);
-    log::info!("Running noprop for {epochs} epochs...");
+    vanillanoprop::info!("Running noprop for {epochs} epochs...");
     let (np_f1, np_add, np_mul, np_mem) = train_noprop(epochs);
-    log::info!("\nComparison after {epochs} epochs:");
-    log::info!(
+    vanillanoprop::info!("\nComparison after {epochs} epochs:");
+    vanillanoprop::info!(
         "Backprop -> Best F1: {bp_f1:.4}, Adds: {bp_add}, Muls: {bp_mul}, Peak Mem: {:.2} MB",
         bp_mem as f64 / (1024.0 * 1024.0)
     );
-    log::info!(
+    vanillanoprop::info!(
         "Noprop   -> Best F1: {np_f1:.4}, Adds: {np_add}, Muls: {np_mul}, Peak Mem: {:.2} MB",
         np_mem as f64 / (1024.0 * 1024.0)
     );

--- a/src/bin/sample_vae.rs
+++ b/src/bin/sample_vae.rs
@@ -19,5 +19,5 @@ fn main() {
         z.set(0, i, e);
     }
     let sample = vae.decode(&z);
-    log::info!("sample first values: {:?}", &sample.data[..10.min(sample.data.len())]);
+    vanillanoprop::info!("sample first values: {:?}", &sample.data[..10.min(sample.data.len())]);
 }

--- a/src/bin/train_backprop.rs
+++ b/src/bin/train_backprop.rs
@@ -116,11 +116,11 @@ fn run_impl<D: Dataset<Item = (Vec<u8>, usize)>>(
         }
         match Model::load(path, &mut params) {
             Ok(m) => {
-                log::info!("Resumed model from {path}");
+                vanillanoprop::info!("Resumed model from {path}");
                 m
             }
             Err(e) => {
-                log::error!("Failed to load model {path}: {e}");
+                vanillanoprop::error!("Failed to load model {path}: {e}");
                 Model::new()
             }
         }
@@ -211,7 +211,7 @@ fn run_impl<D: Dataset<Item = (Vec<u8>, usize)>>(
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
-        log::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
+        vanillanoprop::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -234,7 +234,7 @@ fn run_impl<D: Dataset<Item = (Vec<u8>, usize)>>(
             }
             let param_refs: Vec<&LinearT> = params.iter().map(|p| &**p).collect();
             if let Err(e) = trainer.save("checkpoint.bin", &param_refs) {
-                log::error!("Failed to save checkpoint: {e}");
+                vanillanoprop::error!("Failed to save checkpoint: {e}");
             }
         }
     }
@@ -242,7 +242,7 @@ fn run_impl<D: Dataset<Item = (Vec<u8>, usize)>>(
 
     log_total_ops(math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    log::info!(
+    vanillanoprop::info!(
         "Max memory usage: {:.2} MB",
         peak as f64 / (1024.0 * 1024.0)
     );
@@ -255,7 +255,7 @@ fn run_impl<D: Dataset<Item = (Vec<u8>, usize)>>(
     }
     let param_refs: Vec<&LinearT> = params.iter().map(|p| &**p).collect();
     if let Err(e) = trainer.save("model.bin", &param_refs) {
-        log::error!("Failed to save model: {e}");
+        vanillanoprop::error!("Failed to save model: {e}");
     }
 }
 

--- a/src/bin/train_elmo.rs
+++ b/src/bin/train_elmo.rs
@@ -146,7 +146,7 @@ fn run(
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
-        log::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
+        vanillanoprop::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -163,7 +163,7 @@ fn run(
             log_checkpoint_saved(epoch, avg_f1);
             best_f1 = avg_f1;
             if let Err(e) = save_model("checkpoint.json", &mut encoder, None) {
-                log::error!("Failed to save checkpoint: {e}");
+                vanillanoprop::error!("Failed to save checkpoint: {e}");
             }
         }
     }
@@ -171,12 +171,12 @@ fn run(
 
     log_total_ops(math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    log::info!(
+    vanillanoprop::info!(
         "Max memory usage: {:.2} MB",
         peak as f64 / (1024.0 * 1024.0)
     );
 
     if let Err(e) = save_model("model.json", &mut encoder, None) {
-        log::error!("Failed to save model: {e}");
+        vanillanoprop::error!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_lcm.rs
+++ b/src/bin/train_lcm.rs
@@ -68,12 +68,12 @@ fn run(config: &Config) {
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
-        log::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
+        vanillanoprop::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         pb.inc(1);
     }
     pb.finish_with_message("training done");
 
     if let Err(e) = save_lcm("lcm.json", &model) {
-        log::error!("Failed to save model: {e}");
+        vanillanoprop::error!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_noprop.rs
+++ b/src/bin/train_noprop.rs
@@ -61,7 +61,7 @@ fn main() {
             let mut rng = rng_from_env();
             let eval = |_cfg: Config| rand::random::<f32>();
             let (_best_cfg, best_score) = random_search(&space, 10, eval, &mut rng, &mut logger);
-            log::info!("AutoML best score: {best_score:.4}");
+            vanillanoprop::info!("AutoML best score: {best_score:.4}");
         }
         return;
     }
@@ -247,7 +247,7 @@ fn run(
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
-        log::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
+        vanillanoprop::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -286,7 +286,7 @@ fn run(
             };
             let path = format!("{}/epoch_{}.json", ckpt_dir, epoch);
             if let Err(e) = save_checkpoint(&path, &cp) {
-                log::error!("Failed to save checkpoint: {e}");
+                vanillanoprop::error!("Failed to save checkpoint: {e}");
             }
         }
     }
@@ -294,12 +294,12 @@ fn run(
 
     log_total_ops(math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    log::info!(
+    vanillanoprop::info!(
         "Max memory usage: {:.2} MB",
         peak as f64 / (1024.0 * 1024.0)
     );
 
     if let Err(e) = save_model(&format!("{}/model.json", ckpt_dir), &mut encoder, None) {
-        log::error!("Failed to save model: {e}");
+        vanillanoprop::error!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_resnet.rs
+++ b/src/bin/train_resnet.rs
@@ -128,7 +128,7 @@ fn run(
         }
         let avg_f1 = f1_sum / if sample_cnt > 0.0 { sample_cnt } else { 1.0 };
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}"));
-        log::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
+        vanillanoprop::info!("epoch {epoch} loss {last_loss:.4} f1 {avg_f1:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -145,7 +145,7 @@ fn run(
     pb.finish_with_message("training done");
     log_total_ops(math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    log::info!(
+    vanillanoprop::info!(
         "Max memory usage: {:.2} MB",
         peak as f64 / (1024.0 * 1024.0)
     );

--- a/src/bin/train_rnn.rs
+++ b/src/bin/train_rnn.rs
@@ -123,7 +123,7 @@ fn run(
             step += 1;
         }
         pb.set_message(format!("epoch {epoch} loss {last_loss:.4}"));
-        log::info!("epoch {epoch} loss {last_loss:.4}");
+        vanillanoprop::info!("epoch {epoch} loss {last_loss:.4}");
         if let Some(l) = &mut logger {
             l.log(&MetricRecord {
                 epoch,
@@ -139,6 +139,6 @@ fn run(
     pb.finish_with_message("training done");
 
     if let Err(e) = save_rnn("rnn.json", &mut rnn) {
-        log::error!("Failed to save model: {e}");
+        vanillanoprop::error!("Failed to save model: {e}");
     }
 }

--- a/src/bin/train_self_adapt.rs
+++ b/src/bin/train_self_adapt.rs
@@ -109,6 +109,6 @@ fn main() {
         while let Some(r) = agent.step() {
             total += r;
         }
-        log::info!("episode {} reward {total:.2}", ep + 1);
+        vanillanoprop::info!("episode {} reward {total:.2}", ep + 1);
     }
 }

--- a/src/bin/train_treepo.rs
+++ b/src/bin/train_treepo.rs
@@ -69,6 +69,6 @@ fn main() {
                 break;
             }
         }
-        log::info!("Episode {} complete", episode + 1);
+        vanillanoprop::info!("Episode {} complete", episode + 1);
     }
 }

--- a/src/bin/train_vae.rs
+++ b/src/bin/train_vae.rs
@@ -34,10 +34,10 @@ fn main() {
             trainer.fit(&mut params);
             total += recon_loss + kl_loss;
         }
-        log::info!("epoch {epoch} loss {:.4}", total / pairs.len() as f32);
+        vanillanoprop::info!("epoch {epoch} loss {:.4}", total / pairs.len() as f32);
     }
 
     if let Err(e) = save_vae("vae.json", &vae) {
-        log::error!("failed to save model: {e}");
+        vanillanoprop::error!("failed to save model: {e}");
     }
 }

--- a/src/bin/train_zero_shot_safe.rs
+++ b/src/bin/train_zero_shot_safe.rs
@@ -63,7 +63,7 @@ fn main() {
     }
     let cfg_str = std::fs::read_to_string(&cfg_path).expect("read config");
     let cfg: Config = toml::from_str(&cfg_str).expect("parse config");
-    log::info!(
+    vanillanoprop::info!(
         "discount {} lr {} rollout {}",
         cfg.discount_factor,
         cfg.learning_rate,
@@ -90,7 +90,7 @@ fn main() {
                 break;
             }
         }
-        log::info!(
+        vanillanoprop::info!(
             "Episode {} complete, violations {}",
             ep + 1,
             agent.violations

--- a/src/model.rs
+++ b/src/model.rs
@@ -184,7 +184,7 @@ impl Model {
             fs::create_dir_all(parent)?;
         }
         fs::write(path, bin)?;
-        log::info!("Saved model to {}", path);
+        crate::info!("Saved model to {}", path);
         Ok(())
     }
 
@@ -209,7 +209,7 @@ impl Model {
         for (p, w) in params.iter_mut().zip(state.weights.iter()) {
             p.w = Tensor::from_matrix(vec2_to_matrix(w));
         }
-        log::info!("Loaded model from {}", path);
+        crate::info!("Loaded model from {}", path);
         Ok(Model {
             nodes: state.nodes,
             edges: state.edges,

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -54,7 +54,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
             );
 
             if let Err(e) = load_model("model.json", &mut encoder, &mut decoder) {
-                log::error!("Failed to load model weights: {e}");
+                crate::error!("Failed to load model weights: {e}");
             }
 
             math::reset_matrix_ops();
@@ -85,7 +85,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                 }
             }
 
-            log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
+            crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
             log_total_ops(math::matrix_ops_count());
             best_tok
         }
@@ -93,7 +93,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
             let model = match load_lcm("lcm.json", 28 * 28, 128, 64, 10) {
                 Ok(m) => m,
                 Err(e) => {
-                    log::warn!("Using random LCM weights; failed to load lcm.json: {e}");
+                    crate::warn!("Using random LCM weights; failed to load lcm.json: {e}");
                     LargeConceptModel::new(28 * 28, 128, 64, 10)
                 }
             };
@@ -102,7 +102,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                 let moe_layer = match load_moe("moe.json", 64, 10, n) {
                     Ok(m) => m,
                     Err(e) => {
-                        log::warn!("Using random MoE weights; failed to load moe.json: {e}");
+                        crate::warn!("Using random MoE weights; failed to load moe.json: {e}");
                         let experts: Vec<Box<dyn Layer>> = (0..n)
                             .map(|_| Box::new(LinearT::new(64, 10)) as Box<dyn Layer>)
                             .collect();
@@ -122,11 +122,11 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                         best_tok = t;
                     }
                 }
-                log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
+                crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
                 best_tok
             } else {
                 let pred = model.predict(src);
-                log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, pred);
+                crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, pred);
                 pred
             }
         }
@@ -137,7 +137,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
             let model = match load_rnn("rnn.json", vocab_size, hidden_dim, num_classes) {
                 Ok(m) => m,
                 Err(e) => {
-                    log::warn!("Using random RNN weights; failed to load rnn.json: {e}");
+                    crate::warn!("Using random RNN weights; failed to load rnn.json: {e}");
                     RNN::new_gru(vocab_size, hidden_dim, num_classes)
                 }
             };
@@ -147,7 +147,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                 let moe_layer = match load_moe("moe.json", hidden_dim, num_classes, n) {
                     Ok(m) => m,
                     Err(e) => {
-                        log::warn!("Using random MoE weights; failed to load moe.json: {e}");
+                        crate::warn!("Using random MoE weights; failed to load moe.json: {e}");
                         let experts: Vec<Box<dyn Layer>> = (0..n)
                             .map(|_| {
                                 Box::new(LinearT::new(hidden_dim, num_classes)) as Box<dyn Layer>
@@ -178,7 +178,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                         best_tok = t;
                     }
                 }
-                log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
+                crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
                 best_tok
             } else {
                 let logits = model.forward(&Tensor::from_matrix(enc_x));
@@ -192,7 +192,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                         best_tok = t;
                     }
                 }
-                log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
+                crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
                 best_tok
             }
         }
@@ -201,7 +201,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
             let cnn = match load_cnn("cnn.json", 10) {
                 Ok(cnn) => cnn,
                 Err(e) => {
-                    log::warn!("Using random CNN weights; failed to load cnn.json: {e}");
+                    crate::warn!("Using random CNN weights; failed to load cnn.json: {e}");
                     SimpleCNN::new(10)
                 }
             };
@@ -210,7 +210,7 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                 let moe_layer = match load_moe("moe.json", 28 * 28, 10, n) {
                     Ok(m) => m,
                     Err(e) => {
-                        log::warn!("Using random MoE weights; failed to load moe.json: {e}");
+                        crate::warn!("Using random MoE weights; failed to load moe.json: {e}");
                         let experts: Vec<Box<dyn Layer>> = (0..n)
                             .map(|_| Box::new(LinearT::new(28 * 28, 10)) as Box<dyn Layer>)
                             .collect();
@@ -230,11 +230,11 @@ pub fn run(dataset: DatasetKind, model: Option<&str>, moe: bool, num_experts: us
                         best_tok = t;
                     }
                 }
-                log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
+                crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, best_tok);
                 best_tok
             } else {
                 let pred = cnn.predict(src);
-                log::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, pred);
+                crate::info!("{{\"actual\":{}, \"prediction\":{}}}", tgt, pred);
                 pred
             }
         }

--- a/src/train_cnn.rs
+++ b/src/train_cnn.rs
@@ -238,7 +238,7 @@ pub fn run(
             last_loss = batch_loss;
             f1_sum += batch_f1;
             sample_cnt += 1.0;
-            log::info!("loss {batch_loss:.4} f1 {batch_f1:.4}");
+            crate::info!("loss {batch_loss:.4} f1 {batch_f1:.4}");
             let record = MetricRecord {
                 epoch,
                 step,
@@ -317,7 +317,7 @@ pub fn run(
             };
             let path = format!("{}/epoch_{}.json", ckpt_dir, epoch);
             if let Err(e) = save_checkpoint(&path, &cp) {
-                log::error!("Failed to save checkpoint: {e}");
+                crate::error!("Failed to save checkpoint: {e}");
             }
         }
     }
@@ -330,14 +330,14 @@ pub fn run(
 
     log_total_ops(math::matrix_ops_count());
     let peak = memory::peak_memory_bytes();
-    log::info!(
+    crate::info!(
         "Max memory usage: {:.2} MB",
         peak as f64 / (1024.0 * 1024.0)
     );
     if model == "cnn" {
         if let Some(sc) = cnn.as_any().downcast_ref::<SimpleCNN>() {
             if let Err(e) = save_cnn(&format!("{}/cnn.json", ckpt_dir), sc) {
-                log::error!("Failed to save model: {e}");
+                crate::error!("Failed to save model: {e}");
             }
         }
     }

--- a/src/train_fusion.rs
+++ b/src/train_fusion.rs
@@ -35,6 +35,6 @@ pub fn run() {
         let transformer_t = transformer.forward(audio_input, None);
 
         let fused = Fusion::concat(&cnn_t, &rnn_t, &transformer_t);
-        log::info!("fused representation has shape {:?}", fused.shape);
+        crate::info!("fused representation has shape {:?}", fused.shape);
     }
 }

--- a/src/util/logging.rs
+++ b/src/util/logging.rs
@@ -1,4 +1,4 @@
-use log::info;
+use crate::info;
 
 /// Format a message reporting the total number of matrix operations.
 pub fn format_total_ops(count: usize) -> String {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod logging;
 pub mod progress;
+pub mod simple_logger;

--- a/src/util/simple_logger.rs
+++ b/src/util/simple_logger.rs
@@ -1,0 +1,58 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Logging levels for the simple logger.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+}
+
+static LOG_LEVEL: AtomicUsize = AtomicUsize::new(LogLevel::Info as usize);
+
+/// Set the global log level.
+pub fn set_log_level(level: LogLevel) {
+    LOG_LEVEL.store(level as usize, Ordering::Relaxed);
+}
+
+/// Check if a message at `level` should be logged.
+pub fn enabled(level: LogLevel) -> bool {
+    level as usize <= LOG_LEVEL.load(Ordering::Relaxed)
+}
+
+pub fn timestamp() -> String {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+    format!("{}.{:03}", now.as_secs(), now.subsec_millis())
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {{
+        if $crate::util::simple_logger::enabled($crate::util::simple_logger::LogLevel::Info) {
+            let ts = $crate::util::simple_logger::timestamp();
+            println!("[INFO {ts}] {}", format!($($arg)*));
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {{
+        if $crate::util::simple_logger::enabled($crate::util::simple_logger::LogLevel::Warn) {
+            let ts = $crate::util::simple_logger::timestamp();
+            eprintln!("[WARN {ts}] {}", format!($($arg)*));
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {{
+        if $crate::util::simple_logger::enabled($crate::util::simple_logger::LogLevel::Error) {
+            let ts = $crate::util::simple_logger::timestamp();
+            eprintln!("[ERROR {ts}] {}", format!($($arg)*));
+        }
+    }};
+}
+

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -116,7 +116,7 @@ pub fn save_weights(path: &str, params: &[&LinearT]) -> Result<(), io::Error> {
         fs::create_dir_all(parent)?;
     }
     fs::write(path, bin)?;
-    log::info!("Saved weights to {}", path);
+    crate::info!("Saved weights to {}", path);
     Ok(())
 }
 
@@ -132,7 +132,7 @@ pub fn load_weights(path: &str, params: &mut [&mut LinearT]) -> Result<(), io::E
     for (p, w) in params.iter_mut().zip(wb.weights.iter()) {
         p.w = Tensor::from_matrix(vec2_to_matrix(w));
     }
-    log::info!("Loaded weights from {}", path);
+    crate::info!("Loaded weights from {}", path);
     Ok(())
 }
 
@@ -157,7 +157,7 @@ pub fn save_model(
     };
     let txt = serde_json::to_string(&model).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     fs::write(path, txt)?;
-    log::info!("Saved weights to {}", path);
+    crate::info!("Saved weights to {}", path);
     Ok(())
 }
 
@@ -195,7 +195,7 @@ pub fn load_model(
         }
         params[0].w = Tensor::from_matrix(mat);
     }
-    log::info!("Loaded weights from {}", path);
+    crate::info!("Loaded weights from {}", path);
     Ok(())
 }
 
@@ -214,7 +214,7 @@ pub fn save_cnn(path: &str, cnn: &SimpleCNN) -> Result<(), io::Error> {
     };
     let txt = serde_json::to_string(&model).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     fs::write(path, txt)?;
-    log::info!("Saved CNN weights to {}", path);
+    crate::info!("Saved CNN weights to {}", path);
     Ok(())
 }
 
@@ -230,7 +230,7 @@ pub fn load_cnn(path: &str, num_classes: usize) -> Result<SimpleCNN, io::Error> 
     if !model.bias.is_empty() {
         *bias = model.bias;
     }
-    log::info!("Loaded CNN weights from {}", path);
+    crate::info!("Loaded CNN weights from {}", path);
     Ok(cnn)
 }
 
@@ -249,7 +249,7 @@ pub fn save_moe(path: &str, moe: &mut MixtureOfExpertsT) -> Result<(), io::Error
     };
     let txt = serde_json::to_string(&json).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     fs::write(path, txt)?;
-    log::info!("Saved MoE weights to {}", path);
+    crate::info!("Saved MoE weights to {}", path);
     Ok(())
 }
 
@@ -275,7 +275,7 @@ pub fn load_moe(
             p.w = Tensor::from_matrix(vec2_to_matrix(data));
         }
     }
-    log::info!("Loaded MoE weights from {}", path);
+    crate::info!("Loaded MoE weights from {}", path);
     Ok(moe)
 }
 
@@ -299,7 +299,7 @@ pub fn save_lcm(path: &str, model: &LargeConceptModel) -> Result<(), io::Error> 
     };
     let txt = serde_json::to_string(&json).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     fs::write(path, txt)?;
-    log::info!("Saved LCM weights to {}", path);
+    crate::info!("Saved LCM weights to {}", path);
     Ok(())
 }
 
@@ -333,7 +333,7 @@ pub fn load_lcm(
     if !json.b3.is_empty() {
         *b3 = json.b3.clone();
     }
-    log::info!("Loaded LCM weights from {}", path);
+    crate::info!("Loaded LCM weights from {}", path);
     Ok(model)
 }
 
@@ -345,7 +345,7 @@ pub fn save_rnn(path: &str, model: &mut RNN) -> Result<(), io::Error> {
     let json = RnnJson { params };
     let txt = serde_json::to_string(&json).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     fs::write(path, txt)?;
-    log::info!("Saved RNN weights to {}", path);
+    crate::info!("Saved RNN weights to {}", path);
     Ok(())
 }
 
@@ -363,7 +363,7 @@ pub fn load_rnn(
     for (p, data) in params.iter_mut().zip(json.params.iter()) {
         p.w = Tensor::from_matrix(vec2_to_matrix(data));
     }
-    log::info!("Loaded RNN weights from {}", path);
+    crate::info!("Loaded RNN weights from {}", path);
     Ok(model)
 }
 
@@ -374,7 +374,7 @@ pub fn save_checkpoint<T: Serialize>(path: &str, state: &T) -> Result<(), io::Er
         fs::create_dir_all(parent)?;
     }
     fs::write(path, txt)?;
-    log::info!("Saved checkpoint to {}", path);
+    crate::info!("Saved checkpoint to {}", path);
     Ok(())
 }
 
@@ -382,7 +382,7 @@ pub fn save_checkpoint<T: Serialize>(path: &str, state: &T) -> Result<(), io::Er
 pub fn load_checkpoint<T: for<'de> Deserialize<'de>>(path: &str) -> Result<T, io::Error> {
     let txt = fs::read_to_string(path)?;
     let state = serde_json::from_str(&txt).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    log::info!("Loaded checkpoint from {}", path);
+    crate::info!("Loaded checkpoint from {}", path);
     Ok(state)
 }
 
@@ -396,7 +396,7 @@ pub fn save_vae(path: &str, vae: &VAE) -> Result<(), io::Error> {
     };
     let txt = serde_json::to_string(&json).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     fs::write(path, txt)?;
-    log::info!("Saved VAE weights to {}", path);
+    crate::info!("Saved VAE weights to {}", path);
     Ok(())
 }
 
@@ -425,7 +425,7 @@ pub fn load_vae(
     if !json.dec_fc2.is_empty() {
         vae.dec_fc2.w = Tensor::from_matrix(vec2_to_matrix(&json.dec_fc2));
     }
-    log::info!("Loaded VAE weights from {}", path);
+    crate::info!("Loaded VAE weights from {}", path);
     Ok(vae)
 }
 


### PR DESCRIPTION
## Summary
- add `info!`, `warn!`, and `error!` macros that print timestamped messages
- switch existing logging calls to the new macros
- drop `log` and `env_logger` dependencies

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c561a432d4832fafacfd58356652b8