### PR TITLE
Use read_dir for C build sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,6 @@ dependencies = [
  "cifar_10_loader",
  "criterion",
  "cust",
- "glob",
  "image 0.24.9",
  "libc",
  "matrixmultiply",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ criterion = "0.5"
 
 [build-dependencies]
 cc = "1.0"
-glob = "0.3"
 
 [[bench]]
 name = "mask_topk"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use glob::glob;
+use std::fs;
 
 fn main() {
     if env::var("CARGO_FEATURE_KAI").is_err() {
@@ -7,8 +7,11 @@ fn main() {
     }
 
     let mut build = cc::Build::new();
-    for entry in glob("c_src/*.c").expect("failed to read glob pattern") {
-        build.file(entry.expect("invalid path"));
+    for entry in fs::read_dir("c_src").expect("failed to read c_src directory") {
+        let path = entry.expect("invalid path").path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("c") {
+            build.file(path);
+        }
     }
 
     let target = env::var("TARGET").unwrap_or_default();


### PR DESCRIPTION
## Summary
- enumerate `c_src/` with `std::fs::read_dir` in `build.rs`
- remove `glob` from build dependencies

## Testing
- `cargo test`
- `cargo test --features kai`


------
https://chatgpt.com/codex/tasks/task_e_68c565d440e0832fac90d6c8198b51f8